### PR TITLE
Remove auto-scrolling in buildNestedLocator

### DIFF
--- a/.changeset/early-singers-invite.md
+++ b/.changeset/early-singers-invite.md
@@ -1,0 +1,24 @@
+---
+"pomwright": patch
+---
+
+# Change
+
+buildNestedLocator will no longer attempt to auto-scroll to the final nested locator
+
+Was done previously in an attempt to improve test recordings, but it sometimes causes tearing in screenshots and isn't ideal when using nested locators for visual regression tests.
+
+## Playwright/test compatibility
+
+Tested with the following Playwright/test versions:
+
+- 1.43.1
+- 1.43.0
+- 1.42.1
+- 1.42.0 (not recommended)
+- 1.41.2
+- 1.41.1
+- 1.41.0
+- 1.40.1
+- 1.40.0
+- 1.39.0

--- a/src/helpers/getLocatorBase.ts
+++ b/src/helpers/getLocatorBase.ts
@@ -503,7 +503,6 @@ export class GetLocatorBase<LocatorSchemaPathType extends string> {
 			}
 
 			if (currentLocator != null) {
-				currentLocator.scrollIntoViewIfNeeded().catch(() => {});
 				return currentLocator;
 			}
 		})) as Locator;

--- a/test/pnpm-lock.yaml
+++ b/test/pnpm-lock.yaml
@@ -20,8 +20,8 @@ devDependencies:
     specifier: ^14.1.1
     version: 14.1.1
   pomwright:
-    specifier: ^1.0.0
-    version: 1.0.0(@playwright/test@1.43.1)
+    specifier: ^1.0.1
+    version: 1.0.1(@playwright/test@1.43.1)
 
 packages:
 
@@ -305,10 +305,10 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /pomwright@1.0.0(@playwright/test@1.43.1):
-    resolution: {integrity: sha512-JACHBp3bkEBtZDKhfBonvud9s5z1x0RBWYl9IfxezghttGJUGIxqFbGhDJTx8LR9xxJdYs+YpUM+eLIKYakAlw==}
+  /pomwright@1.0.1(@playwright/test@1.43.1):
+    resolution: {integrity: sha512-mPqCwapT+NwtD/ZcVFjkUxL5XRKmTLXUuUf5LPVH6Gw3vENLbIHqz2zHLwlFBe9/NisHW4V87PFMpZonfVQU6Q==}
     peerDependencies:
-      '@playwright/test': ^1.40.1
+      '@playwright/test': ^1.39.0
     dependencies:
       '@playwright/test': 1.43.1
     dev: true


### PR DESCRIPTION
# Change

buildNestedLocator will no longer attempt to auto-scroll to the final nested locator

Was done previously in an attempt to improve test recordings, but it sometimes causes tearing in screenshots and isn't ideal when using nested locators for visual regression tests.

## Playwright/test compatibility

Tested with the following Playwright/test versions:

- 1.43.1
- 1.43.0
- 1.42.1
- 1.42.0 (not recommended)
- 1.41.2
- 1.41.1
- 1.41.0
- 1.40.1
- 1.40.0
- 1.39.0