### PR TITLE
Feat/filter property and method

### DIFF
--- a/.changeset/silver-points-juggle.md
+++ b/.changeset/silver-points-juggle.md
@@ -1,0 +1,148 @@
+---
+"pomwright": minor
+---
+
+# LocatorSchema filter property and getLocatorSchema.addFilter method
+
+Changes:
+
+- New `filter` property for `LocatorSchema`
+- New `.addFilter()` method for `LocatorSchemaWithMethods`
+
+## New filter property for locatorSchema
+
+The current `LocatorSchema` property `locatorOptions` is actually a `filter`, but it belongs to the `page.locator` method thus it only works for the `locator` property in a `LocatorSchema` object.
+
+The new `filter` property on the other hand is usable for all locator type properties in `LocatorSchema` (locator, role, label, etc.), except for `frameLocator`.
+
+If `filter` is specified on a `LocatorSchema`, it will always be applied and should always be the first filter to be applied/chained to the current locator in the chain of locators (only exception is `locatorOptions`).
+
+Instead of:
+
+```TS
+this.locators.addSchema("main.products.radio@junior", {
+  locator: "radio",
+  locatorOptions: { hasText: "some text"}
+  locatorMethod: GetByMethod.locator
+});
+```
+
+We could use filter:
+
+```TS
+this.locators.addSchema("main.products.radio@junior", {
+  locator: "input",
+  filter: { hasText: "some text"}
+  locatorMethod: GetByMethod.locator
+});
+```
+
+Which as mentioned works for other locator types like role, label, placeholder, altText, title, testid, id, etc., not just locator...:
+
+```TS
+this.locators.addSchema("main.products.radio@junior", {
+  role: "radio",
+  filter: { hasText: "some text"}
+  locatorMethod: GetByMethod.role
+});
+```
+
+Another reason for this change is that a filter and a locator is NOT the same, say we have:
+
+LocatorSchema_A:
+
+```TS
+this.locators.addSchema("main.subscription.form.item.section@header", {
+  role: "region",
+  roleOptions: { name: "Om abonnementet og tilleggstjenester" }
+  locatorMethod: GetByMethod.role
+});
+```
+
+LocatorSchema_B:
+
+```TS
+this.locators.addSchema("main.subscription.form.item.section@header", {
+  locator: "section",
+  filter: { hasText: "Om abonnementet og tilleggstjenester" }
+  locatorMethod: GetByMethod.locator
+});
+```
+
+The locator or nested locator created from LocatorSchema_A will resolve to a `section` in DOM which has the accessibility name "Om abonnementet og tillegstjenester".
+
+While LocatorSchema_B will resolve to a `section` in DOM which contains the text "Om abonnementet og tillegstjenester" somewhere inside the element, possibly in a descendant element, case-insensitively. Note, an HTML `section` without an accessibility name is not an aria region.
+
+But we can also combine them:
+
+```TS
+this.locators.addSchema("main.subscription.form.item.section@header", {
+  role: "region",
+  roleOptions: { name: "Om abonnementet og tillegstjenester" },
+  filter: { hasText: "Mobil 2 GB" }
+  locatorMethod: GetByMethod.role
+});
+```
+
+## New .addFilter() method for locatorSchemaWithMethods
+
+```ts
+.addFilter(
+  "locatorSchemaPath", 
+  options { 
+    has?: Locator | LocatorSchemaPath,
+    hasNot?: Locator | LocatorSchemaPath,
+    hasNotText?: string | RegExp,
+    hasText?: string | RegExp 
+  })
+```
+
+Similar to calling/chaining `.update()`/`.updates()` on `.getLocatorSchema(LocatorSchemaPath)` but using the playwright filter method. E.g.:
+
+Instead of:
+
+```TS
+const allCheckboxesForFiltersRelatedToBrands = await poc
+.getLocatorSchema("main.products.searchControls.filterType.label.checkbox")
+  .updates( { 3: { locatorOptions: { hasText: /Produsent/i } } })
+  .getNestedLocator();
+```
+
+Which currently only works if the LocatorSchema which the whole LocatorSchemaPath resovles to is using the `locator` property, specified in the LocatorSchema by `locatorMethod`, e.g.:
+
+```TS
+// before .update
+this.locators.addSchema("main.products.searchControls.filterType", {
+  locator: ".filterType",
+  locatorMethod: GetByMethod.locator
+});
+```
+
+In most cases it is not, as we only tend to use `locator` for structural DOM elements, and prefer aria based locators for user interactive and/or visible elements, thus updating `locatorOptions` would do nothing for a more likely scenario where the `locatorSchema` uses `role`, or in this case where we're unable to create a unique reliable locator with anything other than a testid:
+
+```TS
+this.locators.addSchema("main.products.searchControls.filterType", {
+  testid: "filter-type",
+  locatorMethod: GetByMethod.testid
+});
+```
+
+So with .addFilter() we're able to do:
+
+```TS
+const allCheckboxesForBrandFilters = await poc
+  .getLocatorSchema("main.products.searchControls.filterType.label.checkbox")
+  .addFilter("main.products.searchControls.filterType", { hasText: /Produsent/i })
+  .getNestedLocator();
+```
+
+Note, if one or more of the LocatorSchema we retrieve has the `filter` property defined, the filter in the locatorSchema will be applied first, then the filter(s) we add through the `.addFilter` method will be chained on. Similarly we can chain the `.addFilter` method just like we're able to chain `.update` and `.updates` methods, e.g.:
+
+```TS
+const allCheckboxesForBrandFilters = await poc
+  .getLocatorSchema("main.products.searchControls.filterType.label.checkbox")
+  .addFilter("main.products.searchControls.filterType", { hasText: /Produsent/i, hasNotText: /utgått/i })
+  .addFilter("main.products.searchControls.filterType.label", { hasText: "Samsung" })
+  .addFilter("main.products.searchControls.filterType.label", { has: poc.page.getByRole("checkbox") })
+  .getNestedLocator();
+```

--- a/.changeset/silver-points-juggle.md
+++ b/.changeset/silver-points-juggle.md
@@ -2,147 +2,512 @@
 "pomwright": minor
 ---
 
-# LocatorSchema filter property and getLocatorSchema.addFilter method
+# LocatorSchema Enhancements: `filter` Property, `.addFilter()`, Updated `.update()`, and Enhanced `getNestedLocator()`
 
-Changes:
+## Overview
 
-- New `filter` property for `LocatorSchema`
-- New `.addFilter()` method for `LocatorSchemaWithMethods`
+This release introduces several key enhancements to the POMWright. These improvements aim to provide greater flexibility, maintainability, and type safety when constructing and managing locators in your Page Object Models (POMs). The main updates include:
 
-## New filter property for locatorSchema
+- **New `filter` Property**: Extends filtering capabilities beyond the `locator` method.
+- **New `.addFilter()` Method**: Facilitates dynamic addition of filters to locators.
+- **Updated `.update()` Method**: Replaces deprecated `.update` and `.updates` methods with a more intuitive interface (none-breaking).
+- **Enhanced `getNestedLocator()` Method**: Shifts from index-based to subPath-based indexing for better readability and maintainability.
+- **Export of `LocatorSchemaWithoutPath`**: Enables partial or full reuse of locator schemas across different contexts.
 
-The current `LocatorSchema` property `locatorOptions` is actually a `filter`, but it belongs to the `page.locator` method thus it only works for the `locator` property in a `LocatorSchema` object.
+## Changes
 
-The new `filter` property on the other hand is usable for all locator type properties in `LocatorSchema` (locator, role, label, etc.), except for `frameLocator`.
+### 1. New `filter` Property for `LocatorSchema`
 
-If `filter` is specified on a `LocatorSchema`, it will always be applied and should always be the first filter to be applied/chained to the current locator in the chain of locators (only exception is `locatorOptions`).
+#### Purpose
 
-Instead of:
+The existing `locatorOptions` property in `LocatorSchema` is specific to the `locator` method, limiting its applicability. The newly introduced `filter` property extends filtering capabilities to all locator types (e.g., `role`, `label`, `placeholder`, `testid`, `id`, etc.), excluding `frameLocator`.
 
-```TS
+#### Behavior
+
+- **Global Applicability**: Unlike `locatorOptions`, the `filter` property can be applied to various locator methods, enhancing versatility.
+- **Priority Application**: When a `filter` is defined, it is always applied and will always be the first filter applied to the locator created from that LocatorSchema, the only exception is `locatorOptions` used with `locator`. This ensures consistent and prioritized filtering across different locator types.
+
+#### Usage Examples
+
+**Before: Using `locatorOptions` (Limited to `locator` method)**
+```typescript
 this.locators.addSchema("main.products.radio@junior", {
   locator: "radio",
-  locatorOptions: { hasText: "some text"}
+  locatorOptions: { hasText: "some text" },
   locatorMethod: GetByMethod.locator
 });
 ```
 
-We could use filter:
-
-```TS
+**After: Using `filter` (Applicable to Multiple Locator Methods)**
+```typescript
 this.locators.addSchema("main.products.radio@junior", {
   locator: "input",
-  filter: { hasText: "some text"}
+  filter: { hasText: "some text" },
   locatorMethod: GetByMethod.locator
 });
 ```
 
-Which as mentioned works for other locator types like role, label, placeholder, altText, title, testid, id, etc., not just locator...:
-
-```TS
+**With `role` Locator Method:**
+```typescript
 this.locators.addSchema("main.products.radio@junior", {
   role: "radio",
-  filter: { hasText: "some text"}
+  filter: { hasText: "some text" },
   locatorMethod: GetByMethod.role
 });
 ```
 
-Another reason for this change is that a filter and a locator is NOT the same, say we have:
-
-LocatorSchema_A:
-
-```TS
+**Combined Example:**
+```typescript
 this.locators.addSchema("main.subscription.form.item.section@header", {
   role: "region",
-  roleOptions: { name: "Om abonnementet og tilleggstjenester" }
+  roleOptions: { name: "Subscription Details" },
+  filter: { hasText: "Mobile 2 GB" },
   locatorMethod: GetByMethod.role
 });
 ```
 
-LocatorSchema_B:
+#### Benefits
 
-```TS
-this.locators.addSchema("main.subscription.form.item.section@header", {
-  locator: "section",
-  filter: { hasText: "Om abonnementet og tilleggstjenester" }
-  locatorMethod: GetByMethod.locator
-});
-```
+- **Enhanced Flexibility**: Apply default filters to various LocatorSchema.
+- **Improved Locator Precision**: Chain multiple filters to narrow down locators based on complex criteria.
+- **Backward Compatibility**: Existing `locatorOptions` works the same way as before, ensuring no disruption to current implementations.
 
-The locator or nested locator created from LocatorSchema_A will resolve to a `section` in DOM which has the accessibility name "Om abonnementet og tillegstjenester".
+### 2. New `.addFilter()` Method for `.getLocatorSchema()`
 
-While LocatorSchema_B will resolve to a `section` in DOM which contains the text "Om abonnementet og tillegstjenester" somewhere inside the element, possibly in a descendant element, case-insensitively. Note, an HTML `section` without an accessibility name is not an aria region.
+#### Purpose
 
-But we can also combine them:
+The `.addFilter()` method allows dynamic addition of filters to any part of the locator chain, enhancing flexibility in locator construction without modifying the original `LocatorSchema` at any point in a test.
 
-```TS
-this.locators.addSchema("main.subscription.form.item.section@header", {
-  role: "region",
-  roleOptions: { name: "Om abonnementet og tillegstjenester" },
-  filter: { hasText: "Mobil 2 GB" }
-  locatorMethod: GetByMethod.role
-});
-```
-
-## New .addFilter() method for locatorSchemaWithMethods
-
-```ts
+#### Method Signature
+```typescript
 .addFilter(
-  "locatorSchemaPath", 
-  options { 
-    has?: Locator | LocatorSchemaPath,
-    hasNot?: Locator | LocatorSchemaPath,
-    hasNotText?: string | RegExp,
-    hasText?: string | RegExp 
-  })
+  subPath: SubPaths<LocatorSchemaPathType, LocatorSubstring>,
+  filterData: FilterEntry
+): LocatorSchemaWithMethods<LocatorSchemaPathType, LocatorSubstring>
 ```
 
-Similar to calling/chaining `.update()`/`.updates()` on `.getLocatorSchema(LocatorSchemaPath)` but using the playwright filter method. E.g.:
+#### Parameters
 
-Instead of:
+- `subPath`: A valid sub-path within the `LocatorSchemaPath` argument to .getLocatorSchema().
+- `filterData`: An object defining the filter criteria, which can include:
+  - `has?: Locator`
+  - `hasNot?: Locator`
+  - `hasText?: string | RegExp`
+  - `hasNotText?: string | RegExp`
 
-```TS
-const allCheckboxesForFiltersRelatedToBrands = await poc
-.getLocatorSchema("main.products.searchControls.filterType.label.checkbox")
-  .updates( { 3: { locatorOptions: { hasText: /Produsent/i } } })
+#### Usage Examples
+
+**Adding Filters to Specific Sub-Paths:**
+```typescript
+const allCheckboxesForBrandFilters = await poc
+  .getLocatorSchema("main.products.searchControls.filterType.label.checkbox")
+  .addFilter("main.products.searchControls.filterType", { hasText: /Producer/i })
   .getNestedLocator();
 ```
 
-Which currently only works if the LocatorSchema which the whole LocatorSchemaPath resovles to is using the `locator` property, specified in the LocatorSchema by `locatorMethod`, e.g.:
-
-```TS
-// before .update
-this.locators.addSchema("main.products.searchControls.filterType", {
-  locator: ".filterType",
-  locatorMethod: GetByMethod.locator
-});
-```
-
-In most cases it is not, as we only tend to use `locator` for structural DOM elements, and prefer aria based locators for user interactive and/or visible elements, thus updating `locatorOptions` would do nothing for a more likely scenario where the `locatorSchema` uses `role`, or in this case where we're unable to create a unique reliable locator with anything other than a testid:
-
-```TS
-this.locators.addSchema("main.products.searchControls.filterType", {
-  testid: "filter-type",
-  locatorMethod: GetByMethod.testid
-});
-```
-
-So with .addFilter() we're able to do:
-
-```TS
-const allCheckboxesForBrandFilters = await poc
+**Chaining Multiple Filters:**
+```typescript
+const refinedCheckboxes = await poc
   .getLocatorSchema("main.products.searchControls.filterType.label.checkbox")
-  .addFilter("main.products.searchControls.filterType", { hasText: /Produsent/i })
-  .getNestedLocator();
-```
-
-Note, if one or more of the LocatorSchema we retrieve has the `filter` property defined, the filter in the locatorSchema will be applied first, then the filter(s) we add through the `.addFilter` method will be chained on. Similarly we can chain the `.addFilter` method just like we're able to chain `.update` and `.updates` methods, e.g.:
-
-```TS
-const allCheckboxesForBrandFilters = await poc
-  .getLocatorSchema("main.products.searchControls.filterType.label.checkbox")
-  .addFilter("main.products.searchControls.filterType", { hasText: /Produsent/i, hasNotText: /utgått/i })
+  .addFilter("main.products.searchControls.filterType", { hasText: /Producer/i, hasNotText: /discontinued/i })
   .addFilter("main.products.searchControls.filterType.label", { hasText: "Samsung" })
   .addFilter("main.products.searchControls.filterType.label", { has: poc.page.getByRole("checkbox") })
   .getNestedLocator();
 ```
+
+**Combining `filter` Property and `.addFilter()`:**
+```typescript
+this.locators.addSchema("main.subscription.form.item.section@header", {
+  role: "region",
+  roleOptions: { name: "Subscription Details" },
+  filter: { hasText: "Mobile 2 GB" },
+  locatorMethod: GetByMethod.role
+});
+
+const specificSection = await poc
+  .getLocatorSchema("main.subscription.form.item.section@header")
+  .addFilter("main.subscription.form.item.section@header", { hasText: "Additional Services" })
+  .getNestedLocator();
+```
+
+#### Benefits
+
+- **Dynamic Filtering**: Add or modify filters on-the-fly without altering the original schema definitions.
+- **Chainability**: Easily chain multiple `.addFilter()` calls to build complex locator chains.
+- **Error Handling**: Attempts to add filters to invalid sub-paths will throw descriptive errors (compile & run-time), ensuring only valid paths are modified.
+
+### 3. Updated `.update()` Method
+
+#### Purpose
+
+The existing `.update` and `.updates` methods are deprecated and will be removed in version 2.0.0. `.update` could only update the last LocatorSchema in the chain and `.updates` relied on index-based updates, which posed maintainability challenges, especially when renaming `LocatorSchemaPath` strings. The new `.update` method leverages valid `subPaths` of `LocatorSchemaPath` instead of indices, enhancing readability and reducing manual maintenance.
+
+#### New Method Signature
+```typescript
+.update(
+  subPath: SubPaths<LocatorSchemaPathType, LocatorSubstring>,
+  modifiedSchema: Partial<LocatorSchemaWithoutPath>
+): LocatorSchemaWithMethods<LocatorSchemaPathType, LocatorSubstring>
+```
+
+#### Deprecation of Old Methods
+
+- **Old `.update(updates: Partial<LocatorSchemaWithoutPath>): LocatorSchemaWithMethods`**
+- **Old `.updates(indexedUpdates: { [index: number]: Partial<LocatorSchemaWithoutPath> | null }): LocatorSchemaWithMethods`**
+
+These methods are marked as deprecated and will be removed in version 2.0.0.
+
+#### Usage Examples
+
+**Case A: Update the Last `LocatorSchema` in the Chain**
+```typescript
+const editBtn = await profile
+  .getLocatorSchema("content.region.details.button.edit")
+  .update("content.region.details.button.edit", { 
+    roleOptions: { name: "new accessibility name" }
+  })
+  .getNestedLocator();
+```
+
+**Case B: Update a `LocatorSchema` Earlier in the Chain**
+```typescript
+const editBtn = await profile
+  .getLocatorSchema("content.region.details.button.edit")
+  .update("content.region.details", { 
+    roleOptions: { name: "new accessibility name" }
+  })
+  .getNestedLocator();
+```
+
+**Case C: Update Multiple `LocatorSchema` in the Chain**
+```typescript
+const editBtn = await profile
+  .getLocatorSchema("content.region.details.button.edit")
+  .update("content", { roleOptions: { name: "new accessibility name" } })
+  .update("content.region", { roleOptions: { name: "new accessibility name" } })
+  .update("content.region.details", { roleOptions: { name: "new accessibility name" } })
+  .update("content.region.details.button", { roleOptions: { name: "new accessibility name" } })
+  .update("content.region.details.button.edit", { roleOptions: { name: "new accessibility name" } })
+  .getNestedLocator();
+```
+
+#### Benefits
+
+- **Enhanced Readability**: Using `LocatorSchemaPath` strings makes the code more intuitive and easier to understand.
+- **Reduced Maintenance**: Eliminates the need to manage index-based references, especially when `LocatorSchemaPath` strings are renamed or restructured.
+- **Type Safety**: Leverages TypeScript's type system to ensure only valid `subPath` strings are used, enhancing developer experience with accurate Intellisense suggestions.
+
+### 4. Enhanced `getNestedLocator()` Method
+
+#### Purpose
+
+The `getNestedLocator()` method has been updated to utilize valid `subPath`'s of `LocatorSchemaPath` instead of numeric indices when specifying `.nth(n)` occurrences within a locator chain. The old index-based method is deprecated and will be removed in version 2.0.0.
+
+#### New Method Signature
+```typescript
+getNestedLocator(
+  subPathIndices?: { [K in SubPaths<LocatorSchemaPathType, LocatorSubstring>]: number | null }
+): Promise<Locator>
+```
+
+#### Deprecation of Old Method
+
+- **Old `getNestedLocator(indices?: { [key: number]: number | null }): Promise<Locator>`**
+
+This method is marked as deprecated and will be removed in version 2.0.0.
+
+#### Usage Examples
+
+**Old Usage (Deprecated):**
+```typescript
+const saveBtn = await profile.getNestedLocator("content.region.details.button.save", { 4: 2 });
+
+const editBtn = await profile.getLocatorSchema("content.region.details.button.edit")
+  .getNestedLocator({ 2: index });
+```
+
+**New Usage:**
+```typescript
+const saveBtn = await profile.getNestedLocator("content.region.details.button.save", {
+  "content.region.details.button.save": 2 
+});
+
+const editBtn = await profile.getLocatorSchema("content.region.details.button.edit")
+  .getNestedLocator({ "content.region.details": index });
+```
+
+#### Benefits
+
+- **Improved Readability**: SubPath-based indexing is more intuitive and aligns with the hierarchical nature of locator paths.
+- **Enhanced Maintainability**: Reduces confusion and manual updates when `LocatorSchemaPath` strings are modified.
+- **Type Safety and Intellisense**: TypeScript provides accurate suggestions for valid `subPath` keys, enhancing the developer experience and reducing errors.
+
+### 5. Export of `LocatorSchemaWithoutPath`
+
+#### Purpose
+
+The `LocatorSchemaWithoutPath` type is now exported through `index.ts`, enabling full or partial reuse of `LocatorSchema` definitions across different `addSchema` calls within the same or different `initLocatorSchemas` functions.
+
+#### Usage Example
+```typescript
+import { GetByMethod, LocatorSchemaWithoutPath } from "pomwright";
+import { missingInputError } from "@common/page-components/errors.locatorSchema.ts";
+
+export type LocatorSchemaPath =
+  | "body"
+  | "body.main"
+  | "body.main.section"
+  | "body.main.section@products"
+  | "body.main.section@userInfo"
+  | "body.main.section@userInfo.input@email"
+  | "body.main.section@userInfo.inputError"
+  | "body.main.section@deliveryInfo";
+
+export function initLocatorSchemas(locators: GetLocatorBase<LocatorSchemaPath>) {
+  locators.addSchema("body", {
+    locator: "body",
+    locatorMethod: GetByMethod.locator,
+  });
+
+  locators.addSchema("body.main", {
+    locator: "main",
+    locatorMethod: GetByMethod.locator,
+  });
+
+  const region: LocatorSchemaWithoutPath = { role: "region", locatorMethod: GetByMethod.role };
+
+  locators.addSchema("body.main.section", {
+    ...region,
+  });
+
+  locators.addSchema("body.main.section@products", {
+    ...region,
+    roleOptions: { name: "Products" },
+  });
+
+  locators.addSchema("body.main.section@userInfo", {
+    ...region,
+    roleOptions: { name: "Contact Info" },
+    filter: { hasText: /e-mail/i },
+  });
+
+  locators.addSchema("body.main.section@userInfo.input@email", {
+    role: "textbox",
+    roleOptions: { name: "Input your e-mail" },
+    locatorMethod: GetByMethod.role,
+  });
+
+  locators.addSchema("body.main.section@userInfo.inputError", {
+    ...missingInputError,
+  });
+
+  locators.addSchema("body.main.section@deliveryInfo", {
+    ...region,
+    roleOptions: { name: "Delivery Info" },
+  });
+}
+```
+
+#### Benefits
+
+- **Code Reusability**: Facilitates the reuse of common locator schema fragments across different contexts, reducing redundancy.
+- **Modular Definitions**: Encourages a modular approach to defining locators, enhancing organization and scalability.
+
+## Deprecations
+
+### 1. Deprecated `.update` and `.updates` Methods
+
+- **Old `.update(updates: Partial<LocatorSchemaWithoutPath>): LocatorSchemaWithMethods`**
+- **Old `.updates(indexedUpdates: { [index: number]: Partial<LocatorSchemaWithoutPath> | null }): LocatorSchemaWithMethods`**
+
+**Reason:**  
+`.updates` relied on index-based updates, which are prone to errors and require manual maintenance, especially when `LocatorSchemaPath` strings are renamed or restructured. While the old `.update` method could only update the last LocatorSchema in the path. Confusing with multiple methods instead of just one.
+
+**Replacement:**  
+Use the new `.update(subPath, modifiedSchema)` method, which leverages `subpath`'s of valid `LocatorSchemaPath` strings for more intuitive and maintainable updates.
+
+**Removal Schedule:**  
+These methods are deprecated and will be removed in version 2.0.0.
+
+### 2. Deprecated Old `getNestedLocator` Method
+
+- **Old `getNestedLocator(indices?: { [key: number]: number | null }): Promise<Locator>`**
+
+**Reason:**  
+Index-based indexing is less readable and requires manual updates when `LocatorSchemaPath` strings change.
+
+**Replacement:**  
+Use the updated `getNestedLocator(subPathIndices?: { [K in SubPaths<LocatorSchemaPathType, LocatorSubstring>]: number | null }): Promise<Locator>` method, which utilizes `LocatorSchemaPath` strings for indexing.
+
+**Removal Schedule:**  
+This method is deprecated and will be removed in version 2.0.0.
+
+## Migration Guide
+
+### Updating `.update` and `.updates` Methods
+
+**Old Usage:**
+```typescript
+const allCheckboxes = await poc
+  .getLocatorSchema("main.products.searchControls.filterType.label.checkbox")
+  .updates({ 3: { locatorOptions: { hasText: /Producer/i } } })
+  .getNestedLocator();
+```
+
+**New Usage:**
+```typescript
+const allCheckboxes = await poc
+  .getLocatorSchema("main.products.searchControls.filterType.label.checkbox")
+  .update("main.products.searchControls.filterType", { locatorOptions: { hasText: /Producer/i } })
+  .getNestedLocator();
+```
+
+### Updating `getNestedLocator` Method
+
+**Old Usage (Deprecated):**
+```typescript
+const saveBtn = await profile.getNestedLocator("content.region.details.button.save", { 4: 2 });
+
+const editBtn = await profile.getLocatorSchema("content.region.details.button.edit")
+  .getNestedLocator({ 2: index });
+```
+
+**New Usage:**
+```typescript
+const saveBtn = await profile.getNestedLocator("content.region.details.button.save", {
+  "content.region.details.button.save": 2 
+});
+
+const editBtn = await profile.getLocatorSchema("content.region.details.button.edit")
+  .getNestedLocator({ "content.region.details": index });
+```
+
+### Utilizing `LocatorSchemaPath` Instead of Indices
+
+Transition from index-based to `LocatorSchemaPath`-based indexing to improve code readability and maintainability.
+
+**Old Example:**
+```typescript
+const allCheckboxes = await poc
+  .getLocatorSchema("main.form.item.checkbox")
+  .updates({ 3: { locatorOptions: { hasText: /Producer/i } } })
+  .getNestedLocator();
+```
+
+**New Example:**
+```typescript
+const allCheckboxes = await poc
+  .getLocatorSchema("main.form.item.checkbox")
+  .update("main.form.item", { locatorOptions: { hasText: /Producer/i } })
+  .getNestedLocator();
+```
+
+## Example in Context
+
+### Defining a LocatorSchema with `filter` and Using `.addFilter()`
+
+```typescript
+// Defining LocatorSchemas
+this.locators.addSchema("body.main.section@userInfo", {
+  role: "region",
+  roleOptions: { name: "Contact Info" },
+  filter: { hasText: /e-mail/i },
+  locatorMethod: GetByMethod.role
+});
+
+// Dynamically adding additional filters using `.addFilter()`
+const specificSection = await poc
+  .getLocatorSchema("body.main.section@userInfo")
+  .addFilter("body.main.section@userInfo", { hasText: "Additional Services" })
+  .getNestedLocator();
+```
+
+### Updating LocatorSchemas with the New `.update()` Method
+
+```typescript
+const editBtn = await profile
+  .getLocatorSchema("content.region.details.button.edit")
+  .update("content.region.details.button.edit", { 
+    roleOptions: { name: "new accessibility name" }
+  })
+  .getNestedLocator();
+```
+
+### Reusing LocatorSchemas with `LocatorSchemaWithoutPath`
+
+```typescript
+import { GetByMethod, LocatorSchemaWithoutPath } from "pomwright";
+import { missingInputError } from "@common/page-components/errors.locatorSchema.ts";
+
+export type LocatorSchemaPath =
+  | "body"
+  | "body.main"
+  | "body.main.section"
+  | "body.main.section@products"
+  | "body.main.section@userInfo"
+  | "body.main.section@userInfo.input@email"
+  | "body.main.section@userInfo.inputError"
+  | "body.main.section@deliveryInfo";
+
+export function initLocatorSchemas(locators: GetLocatorBase<LocatorSchemaPath>) {
+  locators.addSchema("body", {
+    locator: "body",
+    locatorMethod: GetByMethod.locator,
+  });
+
+  locators.addSchema("body.main", {
+    locator: "main",
+    locatorMethod: GetByMethod.locator,
+  });
+
+  const region: LocatorSchemaWithoutPath = { role: "region", locatorMethod: GetByMethod.role };
+
+  locators.addSchema("body.main.section", {
+    ...region,
+  });
+
+  locators.addSchema("body.main.section@products", {
+    ...region,
+    roleOptions: { name: "Products" },
+  });
+
+  locators.addSchema("body.main.section@userInfo", {
+    ...region,
+    roleOptions: { name: "Contact Info" },
+    filter: { hasText: /e-mail/i },
+  });
+
+  locators.addSchema("body.main.section@userInfo.input@email", {
+    role: "textbox",
+    roleOptions: { name: "Input your e-mail" },
+    locatorMethod: GetByMethod.role,
+  });
+
+  locators.addSchema("body.main.section@userInfo.inputError", {
+    ...missingInputError,
+  });
+
+  locators.addSchema("body.main.section@deliveryInfo", {
+    ...region,
+    roleOptions: { name: "Delivery Info" },
+  });
+}
+```
+
+## Notes
+
+- **Filter Application Order:**  
+  The `filter` property in `LocatorSchema` is always applied first, followed by any filters added via `.addFilter()`. This ensures that predefined filters have priority over dynamically added ones.
+
+- **Exclusion of `frameLocator`:**  
+  The `filter` property does not apply to `frameLocator` locators. If you need to filter within frames, use the appropriate Playwright frame methods.
+
+- **Type Safety and Intellisense:**  
+  The new `.update()` and enhanced `getNestedLocator()` methods leverage TypeScript's type system to provide accurate Intellisense suggestions, enhancing developer experience and reducing errors.
+
+## Conclusion
+
+These enhancements to `LocatorSchema` and its associated methods significantly improve the flexibility, readability, and maintainability of locator management within your POMs. By adopting the new `filter` property, `.addFilter()` method, and updated `.update()` & `getNestedLocator()` methods, you can construct more precise and adaptable locators, facilitating robust and scalable test automation.
+
+**Note:**  
+Ensure to migrate away from the deprecated `.update`, `.updates`, and old `getNestedLocator` methods before upgrading to version 2.0.0 to maintain compatibility and leverage the full benefits of these enhancements.

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 9.12
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 9.12
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up pnpm
       uses: pnpm/action-setup@v3
       with:
-        version: '8'
+        version: '9.12'
     
     - name: Set up Node.js
       uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
+---
+"pomwright": minor
+---
+
 # POMWright
 
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/DyHex/POMWright/main.yaml?label=CI%20on%20main) [![NPM Version](https://img.shields.io/npm/v/pomwright)](https://www.npmjs.com/package/pomwright) ![NPM Downloads](https://img.shields.io/npm/dt/pomwright) ![GitHub License](https://img.shields.io/github/license/DyHex/POMWright) [![NPM dev or peer Dependency Version](https://img.shields.io/npm/dependency-version/pomwright/peer/%40playwright%2Ftest)](https://www.npmjs.com/package/playwright) [![Static Badge](https://img.shields.io/badge/created%40-ICE-ffcd00)](https://www.ice.no/)
 
 POMWright is a TypeScript-based framework that implements the Page Object Model Design Pattern, designed specifically to augment Playwright's testing capabilities.
 
-POMWright provides a way of abstracting the implementation details of a web page and encapsulating them into a reusable page object. This approach makes the tests easier to read, write and maintain, and helps reduce duplicated code by breaking down the code into smaller, reusable components, making the code more maintainable and organized.
+POMWright provides a way of abstracting the implementation details of a web page and encapsulating them into a reusable page object. This approach makes the tests easier to read, write, and maintain, and helps reduce duplicated code by breaking down the code into smaller, reusable components, making the code more maintainable and organized.
 
 ## Features
 
 ### Easy Creation of Page Object Classes
 
-Simply extend a class with BasePage to create a Page Object Class (POC).
+Simply extend a class with `BasePage` to create a Page Object Class (POC).
 
 ### Support for Multiple Domains/BaseURLs
 
-Define different base URLs by extending an abstract class with BasePage per domain and have your POCs for each domain extend the abstract classes.
+Define different base URLs by extending an abstract class with `BasePage` per domain and have your POCs for each domain extend the abstract classes.
 
 ### Custom Playwright Fixture Integration
 
@@ -26,15 +30,15 @@ Define comprehensive locators for each POC and share common locators between the
 
 ### Advanced Locator Management
 
-Efficiently manage and chain locators through LocatorSchemaPaths.
+Efficiently manage and chain locators through `LocatorSchemaPath`s.
 
 ### Dynamic Locator Schema Updates
 
-Modify single or multiple locators within a chained locator dynamically during tests.
+Modify single or multiple locators within a chained locator dynamically during tests using the new `.update()` and `.addFilter()` methods.
 
 ### Deep Copy of LocatorSchemas
 
-Ensure that original LocatorSchemas remain immutable and reusable across tests.
+Ensure that original `LocatorSchemas` remain immutable and reusable across tests.
 
 ### Custom HTML Logger
 
@@ -42,7 +46,12 @@ Gain insights with detailed logs for nested locators, integrated with Playwright
 
 ### SessionStorage Handling
 
-Enhance your tests with advanced sessionStorage handling capabilities.
+Enhance your tests with advanced `sessionStorage` handling capabilities.
+
+### Enhanced Locator Filtering
+
+- **New `filter` Property**: Apply filters across various locator types beyond just the `locator` method.
+- **New `.addFilter()` Method**: Dynamically add filters to any part of the locator chain.
 
 ## Installation
 
@@ -70,7 +79,7 @@ Navigate to the "example" folder and install the necessary dependencies:
 pnpm install
 ```
 
-### Playwright browsers
+### Playwright Browsers
 
 Install or update Playwright browsers:
 
@@ -78,9 +87,9 @@ Install or update Playwright browsers:
 pnpm playwright install --with-deps
 ```
 
-### Run tests
+### Run Tests
 
-Execute tests across chromium, firefox, and webkit:
+Execute tests across Chromium, Firefox, and WebKit:
 
 ```bash
 pnpm playwright test
@@ -96,7 +105,7 @@ pnpm playwright test --workers 2  # Set the number of parallel workers
 
 ### Reports
 
-After the tests complete, a Playwright HTML report is available in ./example/playwright-report. Open the index.html file in your browser to view the results.
+After the tests complete, a Playwright HTML report is available in `./example/playwright-report`. Open the `index.html` file in your browser to view the results.
 
 ## Usage
 
@@ -104,7 +113,7 @@ Dive into using POMWright with these examples:
 
 ### Create a Page Object Class (POC)
 
-```TS
+```typescript
 import { Page, TestInfo } from "@playwright/test";
 import { BasePage, PlaywrightReportLogger, GetByMethod } from "pomwright";
 
@@ -156,7 +165,7 @@ export default class Profile extends BasePage<LocatorSchemaPath> {
 
 ### Creating a Custom Playwright Fixture
 
-```TS
+```typescript
 import { test as base } from "pomwright";
 import Profile from "...";
 
@@ -172,11 +181,11 @@ export const test = base.extend<fixtures>({
 });
 ```
 
-### Using the fixture in a Playwright tests
+### Using the Fixture in Playwright Tests
 
-#### Click edit button with a single locator
+#### Click Edit Button with a Single Locator
 
-```TS
+```typescript
 import { test } from ".../fixtures";
 
 test("click edit button with a single locator", async ({ profile }) => {
@@ -190,13 +199,12 @@ test("click edit button with a single locator", async ({ profile }) => {
   const editBtn = await profile.getLocator("content.region.details.button.edit");
 
   await editBtn.click();
-
 });
 ```
 
-#### Click edit button with a nested locator
+#### Click Edit Button with a Nested Locator
 
-```TS
+```typescript
 import { test } from ".../fixtures";
 
 test("click edit button with a nested locator", async ({ profile }) => {
@@ -213,13 +221,12 @@ test("click edit button with a nested locator", async ({ profile }) => {
   const editBtn = await profile.getNestedLocator("content.region.details.button.edit");
 
   await editBtn.click();
-
 });
 ```
 
-#### Specify index for nested locator(s)
+#### Specify Index for Nested Locators
 
-```TS
+```typescript
 import { test } from ".../fixtures";
 
 test("specify index for nested locator(s)", async ({ profile }) => {
@@ -234,17 +241,17 @@ test("specify index for nested locator(s)", async ({ profile }) => {
    * content.region.details.button.edit with .nth(1)
    */
   const editBtn = await profile.getNestedLocator("content.region.details.button.edit", {
-    3: 0, 4: 1
+    "content.region.details": 0, 
+    "content.region.details.button.edit": 1
   });
 
   await editBtn.click();
-
 });
 ```
 
-#### Update a locator before use
+#### Update a Locator Before Use
 
-```TS
+```typescript
 import { test } from ".../fixtures";
 
 test("update a locator before use", async ({ profile }) => {
@@ -259,17 +266,18 @@ test("update a locator before use", async ({ profile }) => {
    * content.region.details.button.edit (updated)
    */
   const editBtn = await profile.getLocatorSchema("content.region.details.button.edit")
-    .update({ roleOptions: { name: "Edit details" }})
+    .update("content.region.details.button.edit", { 
+      roleOptions: { name: "Edit details" }
+    })
     .getNestedLocator();
 
   await editBtn.click();
-
 });
 ```
 
-#### Update a nested locator before use
+#### Update a Nested Locator Before Use
 
-```TS
+```typescript
 import { test } from ".../fixtures";
 
 test("update a nested locator before use", async ({ profile }) => {
@@ -284,22 +292,19 @@ test("update a nested locator before use", async ({ profile }) => {
    * content.region.details.button.edit
    */
   const editBtn = await profile.getLocatorSchema("content.region.details.button.edit")
-    .updates({ 
-      2: { // content.region.details
-        locator: ".profile-details",
-        locatorMethod: GetByMethod.locator
-        } 
-      })
+    .update("content.region.details", { 
+      locator: ".profile-details",
+      locatorMethod: GetByMethod.locator
+    })
     .getNestedLocator();
 
   await editBtn.click();
-
 });
 ```
 
-#### Make multiple versions of a locator
+#### Make Multiple Versions of a Locator
 
-```TS
+```typescript
 import { test } from ".../fixtures";
 
 test("make multiple versions of a locator", async ({ profile }) => {
@@ -312,7 +317,7 @@ test("make multiple versions of a locator", async ({ profile }) => {
   const editBtn = await editBtnSchema.getLocator();
   await editBtn.click();
 
-  editBtnSchema.update({ roleOptions: { name: "Edit details" }});
+  editBtnSchema.update("content.region.details.button.edit", { roleOptions: { name: "Edit details" } });
 
   const editBtnUpdated = await editBtnSchema.getNestedLocator();
   await editBtnUpdated.click();
@@ -321,18 +326,198 @@ test("make multiple versions of a locator", async ({ profile }) => {
    * Calling profile.getLocatorSchema("content.region.details.button.edit") again 
    * will return a new deepCopy of the original LocatorSchema
    */
-
 });
+```
+
+## Deprecations
+
+### 1. Deprecated `.update` and `.updates` Methods
+
+- **Old `.update(updates: Partial<LocatorSchemaWithoutPath>): LocatorSchemaWithMethods`**
+- **Old `.updates(indexedUpdates: { [index: number]: Partial<LocatorSchemaWithoutPath> | null }): LocatorSchemaWithMethods`**
+
+**Reason:**  
+The `.updates` method relied on index-based updates, which are prone to errors and require manual maintenance, especially when `LocatorSchemaPath` strings are renamed or restructured. Additionally, the old `.update` method could only update the last `LocatorSchema` in the chain, making it less flexible.
+
+**Replacement:**  
+Use the new `.update(subPath, modifiedSchema)` method, which leverages valid `subPath`s of `LocatorSchemaPath` strings for more intuitive and maintainable updates.
+
+**Removal Schedule:**  
+These methods are deprecated and will be removed in version 2.0.0.
+
+### 2. Deprecated Old `getNestedLocator` Method
+
+- **Old `getNestedLocator(indices?: { [key: number]: number | null }): Promise<Locator>`**
+
+**Reason:**  
+Index-based indexing is less readable and requires manual updates when `LocatorSchemaPath` strings change.
+
+**Replacement:**  
+Use the updated `getNestedLocator(subPathIndices?: { [K in SubPaths<LocatorSchemaPathType, LocatorSubstring>]: number | null }): Promise<Locator>` method, which utilizes `LocatorSchemaPath` strings for indexing.
+
+**Removal Schedule:**  
+This method is deprecated and will be removed in version 2.0.0.
+
+## Migration Guide
+
+### Updating `.update` and `.updates` Methods
+
+**Old Usage:**
+```typescript
+const allCheckboxes = await poc
+  .getLocatorSchema("main.products.searchControls.filterType.label.checkbox")
+  .updates({ 3: { locatorOptions: { hasText: /Producer/i } } })
+  .getNestedLocator();
+```
+
+**New Usage:**
+```typescript
+const allCheckboxes = await poc
+  .getLocatorSchema("main.products.searchControls.filterType.label.checkbox")
+  .update("main.products.searchControls.filterType", { locatorOptions: { hasText: /Producer/i } })
+  .getNestedLocator();
+```
+
+### Updating `getNestedLocator` Method
+
+**Old Usage (Deprecated):**
+```typescript
+const saveBtn = await profile.getNestedLocator("content.region.details.button.save", { 4: 2 });
+
+const editBtn = await profile.getLocatorSchema("content.region.details.button.edit")
+  .getNestedLocator({ 2: index });
+```
+
+**New Usage:**
+```typescript
+const saveBtn = await profile.getNestedLocator("content.region.details.button.save", {
+  "content.region.details.button.save": 2 
+});
+
+const editBtn = await profile.getLocatorSchema("content.region.details.button.edit")
+  .getNestedLocator({ "content.region.details": index });
+```
+
+### Utilizing `LocatorSchemaPath` Instead of Indices
+
+Transition from index-based to `LocatorSchemaPath`-based indexing to improve code readability and maintainability.
+
+**Old Example:**
+```typescript
+const allCheckboxes = await poc
+  .getLocatorSchema("main.form.item.checkbox")
+  .updates({ 3: { locatorOptions: { hasText: /Producer/i } } })
+  .getNestedLocator();
+```
+
+**New Example:**
+```typescript
+const allCheckboxes = await poc
+  .getLocatorSchema("main.form.item.checkbox")
+  .update("main.form.item", { locatorOptions: { hasText: /Producer/i } })
+  .getNestedLocator();
+```
+
+## Example in Context
+
+### Defining a LocatorSchema with `filter` and Using `.addFilter()`
+
+```typescript
+// Defining LocatorSchemas
+this.locators.addSchema("body.main.section@userInfo", {
+  role: "region",
+  roleOptions: { name: "Contact Info" },
+  filter: { hasText: /e-mail/i },
+  locatorMethod: GetByMethod.role
+});
+
+// Dynamically adding additional filters using `.addFilter()`
+const specificSection = await poc
+  .getLocatorSchema("body.main.section@userInfo")
+  .addFilter("body.main.section@userInfo", { hasText: "Additional Services" })
+  .getNestedLocator();
+```
+
+### Updating LocatorSchemas with the New `.update()` Method
+
+```typescript
+const editBtn = await profile
+  .getLocatorSchema("content.region.details.button.edit")
+  .update("content.region.details.button.edit", { 
+    roleOptions: { name: "new accessibility name" }
+  })
+  .getNestedLocator();
+```
+
+### Reusing LocatorSchemas with `LocatorSchemaWithoutPath`
+
+```typescript
+import { GetByMethod, LocatorSchemaWithoutPath } from "pomwright";
+import { missingInputError } from "@common/page-components/errors.locatorSchema.ts";
+
+export type LocatorSchemaPath =
+  | "body"
+  | "body.main"
+  | "body.main.section"
+  | "body.main.section@products"
+  | "body.main.section@userInfo"
+  | "body.main.section@userInfo.input@email"
+  | "body.main.section@userInfo.inputError"
+  | "body.main.section@deliveryInfo";
+
+export function initLocatorSchemas(locators: GetLocatorBase<LocatorSchemaPath>) {
+  locators.addSchema("body", {
+    locator: "body",
+    locatorMethod: GetByMethod.locator,
+  });
+
+  locators.addSchema("body.main", {
+    locator: "main",
+    locatorMethod: GetByMethod.locator,
+  });
+
+  const region: LocatorSchemaWithoutPath = { role: "region", locatorMethod: GetByMethod.role };
+
+  locators.addSchema("body.main.section", {
+    ...region,
+  });
+
+  locators.addSchema("body.main.section@products", {
+    ...region,
+    roleOptions: { name: "Products" },
+  });
+
+  locators.addSchema("body.main.section@userInfo", {
+    ...region,
+    roleOptions: { name: "Contact Info" },
+    filter: { hasText: /e-mail/i },
+  });
+
+  locators.addSchema("body.main.section@userInfo.input@email", {
+    role: "textbox",
+    roleOptions: { name: "Input your e-mail" },
+    locatorMethod: GetByMethod.role,
+  });
+
+  locators.addSchema("body.main.section@userInfo.inputError", {
+    ...missingInputError,
+  });
+
+  locators.addSchema("body.main.section@deliveryInfo", {
+    ...region,
+    roleOptions: { name: "Delivery Info" },
+  });
+}
 ```
 
 ## Troubleshooting and Support
 
-If you encounter any issues or have questions, please check our issues page or reach out to us directly.
+If you encounter any issues or have questions, please check our [issues page](https://github.com/DyHex/POMWright/issues) or reach out to us directly.
 
 ## Contributing
 
-Pull Requests are welcome!
+Pull Requests are welcome! Please open an issue or submit a pull request for any enhancements or bug fixes.
 
 ## License
 
-POMWright is open-source software licensed under the Apache-2.0 license
+POMWright is open-source software licensed under the [Apache-2.0 license](https://github.com/DyHex/POMWright/blob/main/LICENSE).

--- a/index.ts
+++ b/index.ts
@@ -16,8 +16,8 @@ export { PlaywrightReportLogger };
 import { type AriaRoleType, GetByMethod, type LocatorSchema } from "./src/helpers/locatorSchema.interface";
 export { GetByMethod, type LocatorSchema, type AriaRoleType };
 
-import { GetLocatorBase } from "./src/helpers/getLocatorBase";
-export { GetLocatorBase };
+import { GetLocatorBase, type ModifiedLocatorSchema } from "./src/helpers/getLocatorBase";
+export { GetLocatorBase, type ModifiedLocatorSchema };
 
 import { BaseApi } from "./src/api/baseApi";
 export { BaseApi };

--- a/index.ts
+++ b/index.ts
@@ -16,8 +16,8 @@ export { PlaywrightReportLogger };
 import { type AriaRoleType, GetByMethod, type LocatorSchema } from "./src/helpers/locatorSchema.interface";
 export { GetByMethod, type LocatorSchema, type AriaRoleType };
 
-import { GetLocatorBase, type ModifiedLocatorSchema } from "./src/helpers/getLocatorBase";
-export { GetLocatorBase, type ModifiedLocatorSchema };
+import { GetLocatorBase, type LocatorSchemaWithoutPath } from "./src/helpers/getLocatorBase";
+export { GetLocatorBase, type LocatorSchemaWithoutPath };
 
 import { BaseApi } from "./src/api/baseApi";
 export { BaseApi };

--- a/intTest/fixtures/withOptions.ts
+++ b/intTest/fixtures/withOptions.ts
@@ -1,6 +1,7 @@
 import TestPage from "@page-object-models/testApp/with-options/pages/testPage.page";
 import Color from "@page-object-models/testApp/with-options/pages/testPath/[color]/color.page";
 import TestPath from "@page-object-models/testApp/with-options/pages/testPath/testPath.page";
+import TestFilters from "@page-object-models/testApp/with-options/pages/testfilters/testfilters.page";
 import { expect } from "@playwright/test";
 import { test as base } from "pomwright";
 
@@ -8,6 +9,7 @@ type fixtures = {
 	testPage: TestPage;
 	testPath: TestPath;
 	color: Color;
+	testFilters: TestFilters;
 };
 
 const test = base.extend<fixtures>({
@@ -24,6 +26,11 @@ const test = base.extend<fixtures>({
 	color: async ({ page, log }, use, testInfo) => {
 		const color = new Color(page, testInfo, log);
 		await use(color);
+	},
+
+	testFilters: async ({ page, log }, use, testInfo) => {
+		const testFilters = new TestFilters(page, testInfo, log);
+		await use(testFilters);
 	},
 });
 

--- a/intTest/package.json
+++ b/intTest/package.json
@@ -14,9 +14,10 @@
 		"@types/express": "^4.17.21",
 		"@types/node": "^20.16.6",
 		"express": "^4.21.0",
-		"pomwright": "^1.1.0"
+		"pomwright": "^1.1.1"
 	},
 	"dependencies": {
 		"dotenv": "^16.4.5"
-	}
+	},
+	"packageManager": "pnpm@9.12.0"
 }

--- a/intTest/page-object-models/testApp/with-options/base/baseWithOptions.page.ts
+++ b/intTest/page-object-models/testApp/with-options/base/baseWithOptions.page.ts
@@ -1,5 +1,5 @@
-import { type Page, type TestInfo } from "@playwright/test";
-import { BasePage, type BasePageOptions, type ExtractUrlPathType, PlaywrightReportLogger } from "pomwright";
+import type { Page, TestInfo } from "@playwright/test";
+import { BasePage, type BasePageOptions, type ExtractUrlPathType, type PlaywrightReportLogger } from "pomwright";
 
 // BaseWithOptions extends BasePage and enforces baseUrlType as string
 export default abstract class BaseWithOptions<

--- a/intTest/page-object-models/testApp/with-options/pages/testPage.page.ts
+++ b/intTest/page-object-models/testApp/with-options/pages/testPage.page.ts
@@ -2,8 +2,8 @@ import {
 	type LocatorSchemaPath,
 	initLocatorSchemas,
 } from "@page-object-models/testApp/without-options/pages/testPage.locatorSchema"; // same page, same locator schema
-import { type Page, type TestInfo } from "@playwright/test";
-import { PlaywrightReportLogger } from "pomwright";
+import type { Page, TestInfo } from "@playwright/test";
+import type { PlaywrightReportLogger } from "pomwright";
 import BaseWithOptions from "../base/baseWithOptions.page";
 
 // Note, if BasePageOptions aren't specified, default options are used

--- a/intTest/page-object-models/testApp/with-options/pages/testPath/[color]/color.locatorSchema.ts
+++ b/intTest/page-object-models/testApp/with-options/pages/testPath/[color]/color.locatorSchema.ts
@@ -1,4 +1,4 @@
-import { GetByMethod, GetLocatorBase } from "pomwright";
+import { GetByMethod, type GetLocatorBase } from "pomwright";
 
 /**
  * The following locatorSchema implementation is total overkill for the Color POC, but serves as one possible

--- a/intTest/page-object-models/testApp/with-options/pages/testPath/[color]/color.page.ts
+++ b/intTest/page-object-models/testApp/with-options/pages/testPath/[color]/color.page.ts
@@ -1,7 +1,7 @@
 import { test } from "@fixtures/withOptions";
 import BaseWithOptions from "@page-object-models/testApp/with-options/base/baseWithOptions.page";
 import { type Page, type TestInfo, expect } from "@playwright/test";
-import { PlaywrightReportLogger } from "pomwright";
+import type { PlaywrightReportLogger } from "pomwright";
 import { type LocatorSchemaPath, initLocatorSchemas } from "./color.locatorSchema";
 
 // By providing the urlOptions, the urlPath property now has RegExp type instead of string type (default) for this POC

--- a/intTest/page-object-models/testApp/with-options/pages/testPath/testPath.locatorSchema.ts
+++ b/intTest/page-object-models/testApp/with-options/pages/testPath/testPath.locatorSchema.ts
@@ -1,4 +1,4 @@
-import { GetByMethod, GetLocatorBase } from "pomwright";
+import { GetByMethod, type GetLocatorBase } from "pomwright";
 
 export type LocatorSchemaPath = "body" | "body.link@color";
 

--- a/intTest/page-object-models/testApp/with-options/pages/testPath/testPath.page.ts
+++ b/intTest/page-object-models/testApp/with-options/pages/testPath/testPath.page.ts
@@ -1,7 +1,7 @@
 import { test } from "@fixtures/withOptions";
 import BaseWithOptions from "@page-object-models/testApp/with-options/base/baseWithOptions.page";
 import { type Page, type TestInfo, expect } from "@playwright/test";
-import { PlaywrightReportLogger } from "pomwright";
+import type { PlaywrightReportLogger } from "pomwright";
 import { type LocatorSchemaPath, initLocatorSchemas } from "./testPath.locatorSchema";
 
 // Note, if BasePageOptions aren't specified, default options are used

--- a/intTest/page-object-models/testApp/with-options/pages/testfilters/testfilters.locatorSchema.ts
+++ b/intTest/page-object-models/testApp/with-options/pages/testfilters/testfilters.locatorSchema.ts
@@ -1,0 +1,210 @@
+import type { Locator } from "@playwright/test";
+import { GetByMethod, type GetLocatorBase, type ModifiedLocatorSchema } from "pomwright";
+
+export type LocatorSchemaPath =
+	| "body"
+	| "body.section"
+	| "body.section.heading"
+	| "body.section.button"
+	| "body.section@playground"
+	| "body.section@playground.heading"
+	| "body.section@playground.button"
+	| "body.section@playground.button@red"
+	| "body.section@playground.button@reset"
+	/**
+	 * Fictional LocatorSchema do not exist in the DOM of the /testfilters page:
+	 */
+	| "fictional.filter@undefined"
+	| "fictional.filter@optionsUndefined"
+	| "fictional.locatorWithfilter@allOptions"
+	| "fictional.locatorAndOptionsWithfilter@allOptions"
+	| "fictional.filter@has"
+	| "fictional.filter@hasNot"
+	| "fictional.filter@hasText"
+	| "fictional.filter@hasNotText"
+	| "fictional.filter@hasNotText.filter@hasText"
+	| "fictional.filter@hasNotText.filter@hasText.filter@hasNotText"
+	| "fictional.filter@hasNotText.filter@hasText.filter@hasNotText.filter@hasText";
+
+export function initLocatorSchemas(locators: GetLocatorBase<LocatorSchemaPath>) {
+	locators.addSchema("body", {
+		locator: "body",
+		locatorMethod: GetByMethod.locator,
+	});
+
+	const bodySectionSchema: ModifiedLocatorSchema = { locator: "section", locatorMethod: GetByMethod.locator };
+	locators.addSchema("body.section", bodySectionSchema);
+
+	const bodySectionHeadingSchema: ModifiedLocatorSchema = {
+		role: "heading",
+		roleOptions: {
+			level: 2,
+		},
+		locatorMethod: GetByMethod.role,
+	};
+	locators.addSchema("body.section.heading", bodySectionHeadingSchema);
+
+	const bodySectionButtonSchema: ModifiedLocatorSchema = { role: "button", locatorMethod: GetByMethod.role };
+	locators.addSchema("body.section.button", bodySectionButtonSchema);
+
+	locators.addSchema("body.section@playground", {
+		...bodySectionSchema,
+		filter: { hasText: /Playground/i },
+	});
+
+	locators.addSchema("body.section@playground.heading", {
+		...bodySectionHeadingSchema,
+		roleOptions: {
+			name: "Primary Colors Playground",
+			level: 2,
+			exact: true,
+		},
+	});
+
+	locators.addSchema("body.section@playground.button", { ...bodySectionButtonSchema });
+
+	locators.addSchema("body.section@playground.button@red", {
+		...bodySectionButtonSchema,
+		roleOptions: {
+			name: "Red",
+		},
+	});
+
+	locators.addSchema("body.section@playground.button@reset", {
+		...bodySectionButtonSchema,
+		roleOptions: {
+			name: "Reset Color",
+		},
+	});
+
+	/** --------------------------- Fictional LocatorSchema ---------------------------
+	 * The following LocatorSchema DO NOT exist in the DOM of the /testfilters page
+	 *
+	 * They are used for testing that the getNestedLocator/getLocator methods correctly
+	 * produces correct locator selector strings for LocatorSchema with/without filter.
+	 */
+
+	const allLocatorTypes: ModifiedLocatorSchema = {
+		role: "button",
+		text: "text",
+		label: "label",
+		placeholder: "placeholder",
+		altText: "altText",
+		title: "title",
+		locator: "locator",
+		frameLocator: 'iframe[title="name"]',
+		dataCy: "dataCy",
+		testId: "testId",
+		id: "id",
+		locatorMethod: GetByMethod.role,
+	};
+
+	const allLocatorTypesWithOptions: ModifiedLocatorSchema = {
+		...allLocatorTypes,
+		roleOptions: {
+			name: "roleOptions",
+		},
+		textOptions: {
+			exact: true,
+		},
+		labelOptions: {
+			exact: true,
+		},
+		placeholderOptions: {
+			exact: true,
+		},
+		altTextOptions: {
+			exact: true,
+		},
+		titleOptions: {
+			exact: true,
+		},
+		locatorOptions: {
+			hasText: "locatorOptionsHasText",
+			hasNotText: "locatorOptionshasNotText",
+		},
+	};
+
+	locators.addSchema("fictional.filter@undefined", {
+		...allLocatorTypes,
+	});
+
+	locators.addSchema("fictional.filter@optionsUndefined", {
+		...allLocatorTypes,
+		filter: {
+			has: undefined,
+			hasNot: undefined,
+			hasText: undefined,
+			hasNotText: undefined,
+		},
+	});
+
+	locators.addSchema("fictional.locatorWithfilter@allOptions", {
+		...allLocatorTypes,
+		filter: {
+			has: "has" as unknown as Locator,
+			hasNot: "hasNot" as unknown as Locator,
+			hasText: "hasText",
+			hasNotText: "hasNotText",
+		},
+	});
+
+	locators.addSchema("fictional.locatorAndOptionsWithfilter@allOptions", {
+		...allLocatorTypesWithOptions,
+		filter: {
+			has: "has" as unknown as Locator,
+			hasNot: "hasNot" as unknown as Locator,
+			hasText: "hasText",
+			hasNotText: "hasNotText",
+		},
+	});
+
+	locators.addSchema("fictional.filter@has", {
+		...allLocatorTypes,
+		filter: {
+			has: "has" as unknown as Locator,
+		},
+	});
+
+	locators.addSchema("fictional.filter@hasNot", {
+		...allLocatorTypes,
+		filter: {
+			hasNot: "hasNot" as unknown as Locator,
+		},
+	});
+
+	locators.addSchema("fictional.filter@hasText", {
+		...allLocatorTypes,
+		filter: {
+			hasText: "hasText",
+		},
+	});
+
+	locators.addSchema("fictional.filter@hasNotText", {
+		...allLocatorTypesWithOptions,
+		filter: {
+			hasNotText: "hasNotText",
+		},
+	});
+
+	locators.addSchema("fictional.filter@hasNotText.filter@hasText", {
+		...allLocatorTypesWithOptions,
+		filter: {
+			hasText: "hasText",
+		},
+	});
+
+	locators.addSchema("fictional.filter@hasNotText.filter@hasText.filter@hasNotText", {
+		...allLocatorTypesWithOptions,
+		filter: {
+			hasNotText: "hasNotText",
+		},
+	});
+
+	locators.addSchema("fictional.filter@hasNotText.filter@hasText.filter@hasNotText.filter@hasText", {
+		...allLocatorTypesWithOptions,
+		filter: {
+			hasText: "hasText",
+		},
+	});
+}

--- a/intTest/page-object-models/testApp/with-options/pages/testfilters/testfilters.locatorSchema.ts
+++ b/intTest/page-object-models/testApp/with-options/pages/testfilters/testfilters.locatorSchema.ts
@@ -1,5 +1,5 @@
 import type { Locator } from "@playwright/test";
-import { GetByMethod, type GetLocatorBase, type ModifiedLocatorSchema } from "pomwright";
+import { GetByMethod, type GetLocatorBase, type LocatorSchemaWithoutPath } from "pomwright";
 
 export type LocatorSchemaPath =
 	| "body"
@@ -32,10 +32,10 @@ export function initLocatorSchemas(locators: GetLocatorBase<LocatorSchemaPath>) 
 		locatorMethod: GetByMethod.locator,
 	});
 
-	const bodySectionSchema: ModifiedLocatorSchema = { locator: "section", locatorMethod: GetByMethod.locator };
+	const bodySectionSchema: LocatorSchemaWithoutPath = { locator: "section", locatorMethod: GetByMethod.locator };
 	locators.addSchema("body.section", bodySectionSchema);
 
-	const bodySectionHeadingSchema: ModifiedLocatorSchema = {
+	const bodySectionHeadingSchema: LocatorSchemaWithoutPath = {
 		role: "heading",
 		roleOptions: {
 			level: 2,
@@ -44,7 +44,7 @@ export function initLocatorSchemas(locators: GetLocatorBase<LocatorSchemaPath>) 
 	};
 	locators.addSchema("body.section.heading", bodySectionHeadingSchema);
 
-	const bodySectionButtonSchema: ModifiedLocatorSchema = { role: "button", locatorMethod: GetByMethod.role };
+	const bodySectionButtonSchema: LocatorSchemaWithoutPath = { role: "button", locatorMethod: GetByMethod.role };
 	locators.addSchema("body.section.button", bodySectionButtonSchema);
 
 	locators.addSchema("body.section@playground", {
@@ -84,7 +84,7 @@ export function initLocatorSchemas(locators: GetLocatorBase<LocatorSchemaPath>) 
 	 * produces correct locator selector strings for LocatorSchema with/without filter.
 	 */
 
-	const allLocatorTypes: ModifiedLocatorSchema = {
+	const allLocatorTypes: LocatorSchemaWithoutPath = {
 		role: "button",
 		text: "text",
 		label: "label",
@@ -99,7 +99,7 @@ export function initLocatorSchemas(locators: GetLocatorBase<LocatorSchemaPath>) 
 		locatorMethod: GetByMethod.role,
 	};
 
-	const allLocatorTypesWithOptions: ModifiedLocatorSchema = {
+	const allLocatorTypesWithOptions: LocatorSchemaWithoutPath = {
 		...allLocatorTypes,
 		roleOptions: {
 			name: "roleOptions",

--- a/intTest/page-object-models/testApp/with-options/pages/testfilters/testfilters.page.ts
+++ b/intTest/page-object-models/testApp/with-options/pages/testfilters/testfilters.page.ts
@@ -1,0 +1,24 @@
+import { test } from "@fixtures/withOptions";
+import BaseWithOptions from "@page-object-models/testApp/with-options/base/baseWithOptions.page";
+import { type Page, type TestInfo, expect } from "@playwright/test";
+import type { PlaywrightReportLogger } from "pomwright";
+import { type LocatorSchemaPath, initLocatorSchemas } from "./testfilters.locatorSchema";
+
+// Note, if BasePageOptions aren't specified, default options are used
+export default class TestFilters extends BaseWithOptions<LocatorSchemaPath> {
+	constructor(page: Page, testInfo: TestInfo, pwrl: PlaywrightReportLogger) {
+		super(page, testInfo, "/testfilters", TestFilters.name, pwrl);
+	}
+
+	protected initLocatorSchemas() {
+		initLocatorSchemas(this.locators);
+	}
+
+	async expectThisPage() {
+		await test.step(`Expect Page: ${this.urlPath}`, async () => {
+			await this.page.waitForURL(this.fullUrl);
+		});
+	}
+
+	// add your helper methods here...
+}

--- a/intTest/page-object-models/testApp/without-options/base/base.page.ts
+++ b/intTest/page-object-models/testApp/without-options/base/base.page.ts
@@ -1,5 +1,5 @@
-import { type Page, type TestInfo } from "@playwright/test";
-import { BasePage, PlaywrightReportLogger } from "pomwright";
+import type { Page, TestInfo } from "@playwright/test";
+import { BasePage, type PlaywrightReportLogger } from "pomwright";
 // import helper methods / classes etc, here... (To be used in the Base POC)
 
 export default abstract class Base<LocatorSchemaPathType extends string> extends BasePage<LocatorSchemaPathType> {

--- a/intTest/page-object-models/testApp/without-options/pages/testPage.locatorSchema.ts
+++ b/intTest/page-object-models/testApp/without-options/pages/testPage.locatorSchema.ts
@@ -1,4 +1,4 @@
-import { GetByMethod, GetLocatorBase } from "pomwright";
+import { GetByMethod, type GetLocatorBase } from "pomwright";
 
 export type LocatorSchemaPath =
 	| "topMenu"

--- a/intTest/page-object-models/testApp/without-options/pages/testPage.page.ts
+++ b/intTest/page-object-models/testApp/without-options/pages/testPage.page.ts
@@ -1,5 +1,5 @@
-import { type Page, type TestInfo } from "@playwright/test";
-import { PlaywrightReportLogger } from "pomwright";
+import type { Page, TestInfo } from "@playwright/test";
+import type { PlaywrightReportLogger } from "pomwright";
 import Base from "../base/base.page";
 import { type LocatorSchemaPath, initLocatorSchemas } from "./testPage.locatorSchema";
 

--- a/intTest/playwright.config.ts
+++ b/intTest/playwright.config.ts
@@ -9,10 +9,10 @@ dotenv.config({ override: false });
  */
 export default defineConfig({
 	testDir: "./tests",
-	globalTimeout: 60_000 * 30,
-	timeout: 60_000 * 2,
+	globalTimeout: 60_000 * 5,
+	timeout: 60_000 * 1,
 	expect: {
-		timeout: 10_000,
+		timeout: 5_000,
 	},
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
@@ -28,8 +28,8 @@ export default defineConfig({
 				["list", { printSteps: false }],
 			],
 	use: {
-		actionTimeout: 10_000,
-		navigationTimeout: 30_000,
+		actionTimeout: 5_000,
+		navigationTimeout: 10_000,
 		headless: true,
 		viewport: { width: 1280, height: 720 },
 		ignoreHTTPSErrors: false,

--- a/intTest/playwright.config.ts
+++ b/intTest/playwright.config.ts
@@ -16,17 +16,17 @@ export default defineConfig({
 	},
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
-	retries: process.env.CI ? 2 : 1,
+	retries: process.env.CI ? 1 : 1,
 	workers: process.env.CI ? "50%" : 4,
 	reporter: process.env.CI
 		? [
 				["html", { open: "never" }],
 				["github", { printSteps: false }],
-		  ]
+			]
 		: [
 				["html", { open: "on-failure" }],
 				["list", { printSteps: false }],
-		  ],
+			],
 	use: {
 		actionTimeout: 10_000,
 		navigationTimeout: 30_000,
@@ -68,7 +68,7 @@ export default defineConfig({
 					// stdout: "pipe",
 					// stderr: "pipe",
 				},
-		  ]
+			]
 		: [
 				{
 					command: "pnpm start",
@@ -79,5 +79,5 @@ export default defineConfig({
 					// stdout: "pipe",
 					// stderr: "pipe",
 				},
-		  ],
+			],
 });

--- a/intTest/pnpm-lock.yaml
+++ b/intTest/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       pomwright:
-        specifier: file:..\pomwright-1.1.1.tgz
-        version: file:../pomwright-1.1.1.tgz(@playwright/test@1.47.1)
+        specifier: ^1.1.1
+        version: 1.1.1(@playwright/test@1.47.1)
 
 packages:
 
@@ -271,9 +271,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  pomwright@file:../pomwright-1.1.1.tgz:
-    resolution: {integrity: sha512-m+x97wkHAMn8zV/iS2OeCp9LEpSk2fqjC2fCMRWmjlhcrg4qqPP47QYPRVjxdyZAl57v31NScYSPTmbw+nKp6w==, tarball: file:../pomwright-1.1.1.tgz}
-    version: 1.1.1
+  pomwright@1.1.1:
+    resolution: {integrity: sha512-hl7nrkePjt9OtQJeZV2gL8t0tjcWZaVjURRWN1NLfGcDAuH0vshm4ZUxsBRP2wbGscOEw4cbOojaa4yBfAZB1Q==}
     peerDependencies:
       '@playwright/test': '>=1.41.0 <1.42.0 || >=1.43.0 <2.0.0'
 
@@ -608,7 +607,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  pomwright@file:../pomwright-1.1.1.tgz(@playwright/test@1.47.1):
+  pomwright@1.1.1(@playwright/test@1.47.1):
     dependencies:
       '@playwright/test': 1.47.1
 

--- a/intTest/pnpm-lock.yaml
+++ b/intTest/pnpm-lock.yaml
@@ -1,124 +1,410 @@
-lockfileVersion: '6.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  dotenv:
-    specifier: ^16.4.5
-    version: 16.4.5
+importers:
 
-devDependencies:
-  '@playwright/test':
-    specifier: 1.47.1
-    version: 1.47.1
-  '@types/express':
-    specifier: ^4.17.21
-    version: 4.17.21
-  '@types/node':
-    specifier: ^20.16.6
-    version: 20.16.6
-  express:
-    specifier: ^4.21.0
-    version: 4.21.0
-  pomwright:
-    specifier: ^1.1.0
-    version: 1.1.0(@playwright/test@1.47.1)
+  .:
+    dependencies:
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
+    devDependencies:
+      '@playwright/test':
+        specifier: 1.47.1
+        version: 1.47.1
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.21
+      '@types/node':
+        specifier: ^20.16.6
+        version: 20.16.6
+      express:
+        specifier: ^4.21.0
+        version: 4.21.0
+      pomwright:
+        specifier: file:..\pomwright-1.1.1.tgz
+        version: file:../pomwright-1.1.1.tgz(@playwright/test@1.47.1)
 
 packages:
 
-  /@playwright/test@1.47.1:
+  '@playwright/test@1.47.1':
     resolution: {integrity: sha512-dbWpcNQZ5nj16m+A5UNScYx7HX5trIy7g4phrcitn+Nk83S32EBX/CLU4hiF4RGKX/yRc93AAqtfaXB7JWBd4Q==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@types/body-parser@1.19.5':
+    resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/express-serve-static-core@4.19.5':
+    resolution: {integrity: sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==}
+
+  '@types/express@4.17.21':
+    resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
+
+  '@types/http-errors@2.0.4':
+    resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
+
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
+  '@types/node@20.16.6':
+    resolution: {integrity: sha512-T7PpxM/6yeDE+AdlVysT62BX6/bECZOmQAgiFg5NoBd5MQheZ3tzal7f1wvzfiEcmrcJNRi2zRr2nY2zF+0uqw==}
+
+  '@types/qs@6.9.16':
+    resolution: {integrity: sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@0.17.4':
+    resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
+
+  '@types/serve-static@1.15.7':
+    resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
+
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  body-parser@1.20.3:
+    resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind@1.0.7:
+    resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
+    engines: {node: '>= 0.4'}
+
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.0.6:
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+
+  cookie@0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  dotenv@16.4.5:
+    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
+    engines: {node: '>=12'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.0:
+    resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  express@4.21.0:
+    resolution: {integrity: sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==}
+    engines: {node: '>= 0.10.0'}
+
+  finalhandler@1.3.1:
+    resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
+    engines: {node: '>= 0.8'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.2.4:
+    resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.0.1:
+    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.0.3:
+    resolution: {integrity: sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.0.3:
+    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  object-inspect@1.13.1:
+    resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-to-regexp@0.1.10:
+    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
+
+  playwright-core@1.47.1:
+    resolution: {integrity: sha512-i1iyJdLftqtt51mEk6AhYFaAJCDx0xQ/O5NU8EKaWFgMjItPVma542Nh/Aq8aLCjIJSzjaiEQGW/nyqLkGF1OQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.47.1:
+    resolution: {integrity: sha512-SUEKi6947IqYbKxRiqnbUobVZY4bF1uu+ZnZNJX9DfU1tlf2UhWfvVjLf01pQx9URsOr18bFVUKXmanYWhbfkw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  pomwright@file:../pomwright-1.1.1.tgz:
+    resolution: {integrity: sha512-m+x97wkHAMn8zV/iS2OeCp9LEpSk2fqjC2fCMRWmjlhcrg4qqPP47QYPRVjxdyZAl57v31NScYSPTmbw+nKp6w==, tarball: file:../pomwright-1.1.1.tgz}
+    version: 1.1.1
+    peerDependencies:
+      '@playwright/test': '>=1.41.0 <1.42.0 || >=1.43.0 <2.0.0'
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.13.0:
+    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@2.5.2:
+    resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+    engines: {node: '>= 0.8'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@0.19.0:
+    resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
+    engines: {node: '>= 0.8.0'}
+
+  serve-static@1.16.2:
+    resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
+    engines: {node: '>= 0.8.0'}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  side-channel@1.0.6:
+    resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
+    engines: {node: '>= 0.4'}
+
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+snapshots:
+
+  '@playwright/test@1.47.1':
     dependencies:
       playwright: 1.47.1
-    dev: true
 
-  /@types/body-parser@1.19.5:
-    resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
+  '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
       '@types/node': 20.16.6
-    dev: true
 
-  /@types/connect@3.4.38:
-    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+  '@types/connect@3.4.38':
     dependencies:
       '@types/node': 20.16.6
-    dev: true
 
-  /@types/express-serve-static-core@4.19.5:
-    resolution: {integrity: sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==}
+  '@types/express-serve-static-core@4.19.5':
     dependencies:
       '@types/node': 20.16.6
       '@types/qs': 6.9.16
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
-    dev: true
 
-  /@types/express@4.17.21:
-    resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
+  '@types/express@4.17.21':
     dependencies:
       '@types/body-parser': 1.19.5
       '@types/express-serve-static-core': 4.19.5
       '@types/qs': 6.9.16
       '@types/serve-static': 1.15.7
-    dev: true
 
-  /@types/http-errors@2.0.4:
-    resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
-    dev: true
+  '@types/http-errors@2.0.4': {}
 
-  /@types/mime@1.3.5:
-    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
-    dev: true
+  '@types/mime@1.3.5': {}
 
-  /@types/node@20.16.6:
-    resolution: {integrity: sha512-T7PpxM/6yeDE+AdlVysT62BX6/bECZOmQAgiFg5NoBd5MQheZ3tzal7f1wvzfiEcmrcJNRi2zRr2nY2zF+0uqw==}
+  '@types/node@20.16.6':
     dependencies:
       undici-types: 6.19.8
-    dev: true
 
-  /@types/qs@6.9.16:
-    resolution: {integrity: sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==}
-    dev: true
+  '@types/qs@6.9.16': {}
 
-  /@types/range-parser@1.2.7:
-    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
-    dev: true
+  '@types/range-parser@1.2.7': {}
 
-  /@types/send@0.17.4:
-    resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
+  '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
       '@types/node': 20.16.6
-    dev: true
 
-  /@types/serve-static@1.15.7:
-    resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
+  '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
       '@types/node': 20.16.6
       '@types/send': 0.17.4
-    dev: true
 
-  /accepts@1.3.8:
-    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
-    engines: {node: '>= 0.6'}
+  accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
-    dev: true
 
-  /array-flatten@1.1.1:
-    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
-    dev: true
+  array-flatten@1.1.1: {}
 
-  /body-parser@1.20.3:
-    resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
-    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+  body-parser@1.20.3:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -134,118 +420,60 @@ packages:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
-    dev: true
+  bytes@3.1.2: {}
 
-  /call-bind@1.0.7:
-    resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
-    engines: {node: '>= 0.4'}
+  call-bind@1.0.7:
     dependencies:
       es-define-property: 1.0.0
       es-errors: 1.3.0
       function-bind: 1.1.2
       get-intrinsic: 1.2.4
       set-function-length: 1.2.2
-    dev: true
 
-  /content-disposition@0.5.4:
-    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
-    engines: {node: '>= 0.6'}
+  content-disposition@0.5.4:
     dependencies:
       safe-buffer: 5.2.1
-    dev: true
 
-  /content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  content-type@1.0.5: {}
 
-  /cookie-signature@1.0.6:
-    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
-    dev: true
+  cookie-signature@1.0.6: {}
 
-  /cookie@0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  cookie@0.6.0: {}
 
-  /debug@2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
+  debug@2.6.9:
     dependencies:
       ms: 2.0.0
-    dev: true
 
-  /define-data-property@1.1.4:
-    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
-    engines: {node: '>= 0.4'}
+  define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.0
       es-errors: 1.3.0
       gopd: 1.0.1
-    dev: true
 
-  /depd@2.0.0:
-    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
-    engines: {node: '>= 0.8'}
-    dev: true
+  depd@2.0.0: {}
 
-  /destroy@1.2.0:
-    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
-    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-    dev: true
+  destroy@1.2.0: {}
 
-  /dotenv@16.4.5:
-    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
-    engines: {node: '>=12'}
-    dev: false
+  dotenv@16.4.5: {}
 
-  /ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
-    dev: true
+  ee-first@1.1.1: {}
 
-  /encodeurl@1.0.2:
-    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
-    engines: {node: '>= 0.8'}
-    dev: true
+  encodeurl@1.0.2: {}
 
-  /encodeurl@2.0.0:
-    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
-    engines: {node: '>= 0.8'}
-    dev: true
+  encodeurl@2.0.0: {}
 
-  /es-define-property@1.0.0:
-    resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
-    engines: {node: '>= 0.4'}
+  es-define-property@1.0.0:
     dependencies:
       get-intrinsic: 1.2.4
-    dev: true
 
-  /es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-    dev: true
+  es-errors@1.3.0: {}
 
-  /escape-html@1.0.3:
-    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
-    dev: true
+  escape-html@1.0.3: {}
 
-  /etag@1.8.1:
-    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  etag@1.8.1: {}
 
-  /express@4.21.0:
-    resolution: {integrity: sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==}
-    engines: {node: '>= 0.10.0'}
+  express@4.21.0:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
@@ -280,11 +508,8 @@ packages:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /finalhandler@1.3.1:
-    resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
-    engines: {node: '>= 0.8'}
+  finalhandler@1.3.1:
     dependencies:
       debug: 2.6.9
       encodeurl: 2.0.0
@@ -295,227 +520,121 @@ packages:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /forwarded@0.2.0:
-    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  forwarded@0.2.0: {}
 
-  /fresh@0.5.2:
-    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  fresh@0.5.2: {}
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    requiresBuild: true
-    dev: true
+  fsevents@2.3.2:
     optional: true
 
-  /function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-    dev: true
+  function-bind@1.1.2: {}
 
-  /get-intrinsic@1.2.4:
-    resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
-    engines: {node: '>= 0.4'}
+  get-intrinsic@1.2.4:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
       has-proto: 1.0.3
       has-symbols: 1.0.3
       hasown: 2.0.2
-    dev: true
 
-  /gopd@1.0.1:
-    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
+  gopd@1.0.1:
     dependencies:
       get-intrinsic: 1.2.4
-    dev: true
 
-  /has-property-descriptors@1.0.2:
-    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+  has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.0
-    dev: true
 
-  /has-proto@1.0.3:
-    resolution: {integrity: sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==}
-    engines: {node: '>= 0.4'}
-    dev: true
+  has-proto@1.0.3: {}
 
-  /has-symbols@1.0.3:
-    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
-    engines: {node: '>= 0.4'}
-    dev: true
+  has-symbols@1.0.3: {}
 
-  /hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
+  hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
-    dev: true
 
-  /http-errors@2.0.0:
-    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
-    engines: {node: '>= 0.8'}
+  http-errors@2.0.0:
     dependencies:
       depd: 2.0.0
       inherits: 2.0.4
       setprototypeof: 1.2.0
       statuses: 2.0.1
       toidentifier: 1.0.1
-    dev: true
 
-  /iconv-lite@0.4.24:
-    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
-    engines: {node: '>=0.10.0'}
+  iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
-    dev: true
 
-  /inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: true
+  inherits@2.0.4: {}
 
-  /ipaddr.js@1.9.1:
-    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
-    engines: {node: '>= 0.10'}
-    dev: true
+  ipaddr.js@1.9.1: {}
 
-  /media-typer@0.3.0:
-    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  media-typer@0.3.0: {}
 
-  /merge-descriptors@1.0.3:
-    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
-    dev: true
+  merge-descriptors@1.0.3: {}
 
-  /methods@1.1.2:
-    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  methods@1.1.2: {}
 
-  /mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  mime-db@1.52.0: {}
 
-  /mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
+  mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
-    dev: true
 
-  /mime@1.6.0:
-    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
-    engines: {node: '>=4'}
-    hasBin: true
-    dev: true
+  mime@1.6.0: {}
 
-  /ms@2.0.0:
-    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
-    dev: true
+  ms@2.0.0: {}
 
-  /ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-    dev: true
+  ms@2.1.3: {}
 
-  /negotiator@0.6.3:
-    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  negotiator@0.6.3: {}
 
-  /object-inspect@1.13.1:
-    resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
-    dev: true
+  object-inspect@1.13.1: {}
 
-  /on-finished@2.4.1:
-    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
-    engines: {node: '>= 0.8'}
+  on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
-    dev: true
 
-  /parseurl@1.3.3:
-    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
-    engines: {node: '>= 0.8'}
-    dev: true
+  parseurl@1.3.3: {}
 
-  /path-to-regexp@0.1.10:
-    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
-    dev: true
+  path-to-regexp@0.1.10: {}
 
-  /playwright-core@1.47.1:
-    resolution: {integrity: sha512-i1iyJdLftqtt51mEk6AhYFaAJCDx0xQ/O5NU8EKaWFgMjItPVma542Nh/Aq8aLCjIJSzjaiEQGW/nyqLkGF1OQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-    dev: true
+  playwright-core@1.47.1: {}
 
-  /playwright@1.47.1:
-    resolution: {integrity: sha512-SUEKi6947IqYbKxRiqnbUobVZY4bF1uu+ZnZNJX9DfU1tlf2UhWfvVjLf01pQx9URsOr18bFVUKXmanYWhbfkw==}
-    engines: {node: '>=18'}
-    hasBin: true
+  playwright@1.47.1:
     dependencies:
       playwright-core: 1.47.1
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
-  /pomwright@1.1.0(@playwright/test@1.47.1):
-    resolution: {integrity: sha512-uOYkIUKo9LbloE/qJvVXtYsoWWGtHRZ+om7JB+KvaInR963JI1RocXZwKegJAgL2WzIJpC5qmv9Ajs0l0+Vs4Q==}
-    peerDependencies:
-      '@playwright/test': '>=1.41.0 <1.42.0 || >=1.43.0 <2.0.0'
+  pomwright@file:../pomwright-1.1.1.tgz(@playwright/test@1.47.1):
     dependencies:
       '@playwright/test': 1.47.1
-    dev: true
 
-  /proxy-addr@2.0.7:
-    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
-    engines: {node: '>= 0.10'}
+  proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-    dev: true
 
-  /qs@6.13.0:
-    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
-    engines: {node: '>=0.6'}
+  qs@6.13.0:
     dependencies:
       side-channel: 1.0.6
-    dev: true
 
-  /range-parser@1.2.1:
-    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  range-parser@1.2.1: {}
 
-  /raw-body@2.5.2:
-    resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
-    engines: {node: '>= 0.8'}
+  raw-body@2.5.2:
     dependencies:
       bytes: 3.1.2
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
-    dev: true
 
-  /safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-    dev: true
+  safe-buffer@5.2.1: {}
 
-  /safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-    dev: true
+  safer-buffer@2.1.2: {}
 
-  /send@0.19.0:
-    resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
-    engines: {node: '>= 0.8.0'}
+  send@0.19.0:
     dependencies:
       debug: 2.6.9
       depd: 2.0.0
@@ -532,11 +651,8 @@ packages:
       statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /serve-static@1.16.2:
-    resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
-    engines: {node: '>= 0.8.0'}
+  serve-static@1.16.2:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -544,11 +660,8 @@ packages:
       send: 0.19.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /set-function-length@1.2.2:
-    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
-    engines: {node: '>= 0.4'}
+  set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
       es-errors: 1.3.0
@@ -556,55 +669,29 @@ packages:
       get-intrinsic: 1.2.4
       gopd: 1.0.1
       has-property-descriptors: 1.0.2
-    dev: true
 
-  /setprototypeof@1.2.0:
-    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
-    dev: true
+  setprototypeof@1.2.0: {}
 
-  /side-channel@1.0.6:
-    resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
-    engines: {node: '>= 0.4'}
+  side-channel@1.0.6:
     dependencies:
       call-bind: 1.0.7
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
       object-inspect: 1.13.1
-    dev: true
 
-  /statuses@2.0.1:
-    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
-    engines: {node: '>= 0.8'}
-    dev: true
+  statuses@2.0.1: {}
 
-  /toidentifier@1.0.1:
-    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
-    engines: {node: '>=0.6'}
-    dev: true
+  toidentifier@1.0.1: {}
 
-  /type-is@1.6.18:
-    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
-    engines: {node: '>= 0.6'}
+  type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
-    dev: true
 
-  /undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
-    dev: true
+  undici-types@6.19.8: {}
 
-  /unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
-    engines: {node: '>= 0.8'}
-    dev: true
+  unpipe@1.0.0: {}
 
-  /utils-merge@1.0.1:
-    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
-    engines: {node: '>= 0.4.0'}
-    dev: true
+  utils-merge@1.0.1: {}
 
-  /vary@1.1.2:
-    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
-    engines: {node: '>= 0.8'}
-    dev: true
+  vary@1.1.2: {}

--- a/intTest/server.js
+++ b/intTest/server.js
@@ -1,5 +1,5 @@
 const express = require("express");
-const path = require("path");
+const path = require("node:path");
 
 const app = express();
 const port = 8080;
@@ -58,6 +58,57 @@ app.get("/testpath", (req, res) => {
             const randomColor = generateRandomColor(); // Generate a new random color
             window.location.href = '/testpath/' + randomColor; // Navigate to the random color URL
           });
+        </script>
+      </body>
+    </html>
+  `);
+});
+
+// Route to handle "/testfilters"
+app.get("/testfilters", (req, res) => {
+	res.send(`
+    <html>
+      <body style="margin: 0; padding: 20px; font-family: Arial, sans-serif;">
+        <section id="section1" style="margin-bottom: 20px; border: 1px solid black; padding: 10px;">
+          <h2 style="color: silver; text-shadow: 1px 1px 1px black;">Primary Colors Section</h2>
+          <button style="background-color: red; color: white; padding: 10px;" onclick="changeColor('section1', 'red')">Red</button>
+          <button style="background-color: blue; color: white; padding: 10px;" onclick="changeColor('section1', 'blue')">Blue</button>
+          <button style="background-color: green; color: white; padding: 10px;" onclick="changeColor('section1', 'green')">Green</button>
+          <button style="background-color: lightgray; color: black; padding: 10px;" onclick="resetColor('section1')">Reset Color</button>
+        </section>
+
+        <section id="section2" style="margin-bottom: 20px; border: 1px solid black; padding: 10px;">
+          <h2 style="color: silver; text-shadow: 1px 1px 1px black;">Primary Colors Explorer</h2>
+          <button style="background-color: red; color: white; padding: 10px;" onclick="changeColor('section2', 'red')">Red</button>
+          <button style="background-color: blue; color: white; padding: 10px;" onclick="changeColor('section2', 'blue')">Blue</button>
+          <button style="background-color: green; color: white; padding: 10px;" onclick="changeColor('section2', 'green')">Green</button>
+          <button style="background-color: lightgray; color: black; padding: 10px;" onclick="resetColor('section2')">Reset Color</button>
+        </section>
+
+        <section id="section3" aria-label="Accessible Section" style="margin-bottom: 20px; border: 1px solid black; padding: 10px;">
+          <h2 style="color: silver; text-shadow: 1px 1px 1px black;">Primary Colors Test</h2>
+          <button style="background-color: red; color: white; padding: 10px;" onclick="changeColor('section3', 'red')">Red</button>
+          <button style="background-color: blue; color: white; padding: 10px;" onclick="changeColor('section3', 'blue')">Blue</button>
+          <button style="background-color: green; color: white; padding: 10px;" onclick="changeColor('section3', 'green')">Green</button>
+          <button style="background-color: lightgray; color: black; padding: 10px;" onclick="resetColor('section3')">Reset Color</button>
+        </section>
+
+        <section id="section4" style="margin-bottom: 20px; border: 1px solid black; padding: 10px;">
+          <h2 style="color: silver; text-shadow: 1px 1px 1px black;">Primary Colors Playground</h2>
+          <button style="background-color: red; color: white; padding: 10px;" onclick="changeColor('section4', 'red')">Red</button>
+          <button style="background-color: blue; color: white; padding: 10px;" onclick="changeColor('section4', 'blue')">Blue</button>
+          <button style="background-color: green; color: white; padding: 10px;" onclick="changeColor('section4', 'green')">Green</button>
+          <button style="background-color: lightgray; color: black; padding: 10px;" onclick="resetColor('section4')">Reset Color</button>
+        </section>
+
+        <script>
+          function changeColor(sectionId, color) {
+            document.getElementById(sectionId).style.backgroundColor = color;
+          }
+
+          function resetColor(sectionId) {
+            document.getElementById(sectionId).style.backgroundColor = "";
+          }
         </script>
       </body>
     </html>

--- a/intTest/tests/with-options/locatorSchema/getNestedLocator.filter.spec.ts
+++ b/intTest/tests/with-options/locatorSchema/getNestedLocator.filter.spec.ts
@@ -101,7 +101,7 @@ test.describe("getNestedLocator for locatorSchema with filter property", () => {
 		);
 	});
 
-	test("filter with hasText", async ({ testFilters, log }) => {
+	test("filter with hasText", async ({ testFilters }) => {
 		await testFilters.page.goto(testFilters.fullUrl);
 
 		const playgroundRed = await testFilters.getNestedLocator("body.section@playground.button@red");
@@ -113,22 +113,12 @@ test.describe("getNestedLocator for locatorSchema with filter property", () => {
 			"locator('body').locator(locator('section')).filter({ hasText: /Playground/i }).locator(getByRole('button', { name: 'Reset Color' }))",
 		);
 
-		log.setLogLevel("debug");
-
 		const reset1 = await testFilters
 			.getLocatorSchema("body.section@playground.button@reset")
 			.addFilter("body.section@playground", { hasText: /Primary Colors/i })
 			.addFilter("body.section@playground.button@reset", { hasText: /Reset/i })
 			.addFilter("body.section@playground.button@reset", { hasText: /Color/i })
-			// .updates({ 1: { locator: "OLD_UPDATES" } })
-			// .update({ locator: "OLD_UPDATE..." })
-			// .update("body.section@playground.button@reset", { roleOptions: { name: "SHINY NEW" } })
-			// .getNestedLocator({ 1: 0, 2: 0 });
 			.getNestedLocator();
-		// .getNestedLocator({ "body": 2, "body.section@playground": 1, "body.section@playground.button@reset": 0 });
-		// .getNestedLocator({ body: 2, "body.section@playground": 1 });
-
-		log.resetLogLevel();
 
 		expect(`${reset1}`).not.toEqual(
 			"locator('body').locator(locator('section')).filter({ hasText: /Playground/i }).filter({ hasText: /Primary Colors/i }).first().locator(getByRole('button', { name: 'Reset Color' })).filter({ hasText: /Reset/i }).filter({ hasText: /Color/i }).first()",

--- a/intTest/tests/with-options/locatorSchema/getNestedLocator.filter.spec.ts
+++ b/intTest/tests/with-options/locatorSchema/getNestedLocator.filter.spec.ts
@@ -101,7 +101,7 @@ test.describe("getNestedLocator for locatorSchema with filter property", () => {
 		);
 	});
 
-	test("filter with hasText", async ({ testFilters }) => {
+	test("filter with hasText", async ({ testFilters, log }) => {
 		await testFilters.page.goto(testFilters.fullUrl);
 
 		const playgroundRed = await testFilters.getNestedLocator("body.section@playground.button@red");
@@ -113,14 +113,24 @@ test.describe("getNestedLocator for locatorSchema with filter property", () => {
 			"locator('body').locator(locator('section')).filter({ hasText: /Playground/i }).locator(getByRole('button', { name: 'Reset Color' }))",
 		);
 
+		log.setLogLevel("debug");
+
 		const reset1 = await testFilters
 			.getLocatorSchema("body.section@playground.button@reset")
 			.addFilter("body.section@playground", { hasText: /Primary Colors/i })
 			.addFilter("body.section@playground.button@reset", { hasText: /Reset/i })
 			.addFilter("body.section@playground.button@reset", { hasText: /Color/i })
-			.getNestedLocator({ 1: 0, 2: 0 });
+			// .updates({ 1: { locator: "OLD_UPDATES" } })
+			// .update({ locator: "OLD_UPDATE..." })
+			// .update("body.section@playground.button@reset", { roleOptions: { name: "SHINY NEW" } })
+			// .getNestedLocator({ 1: 0, 2: 0 });
+			.getNestedLocator();
+		// .getNestedLocator({ "body": 2, "body.section@playground": 1, "body.section@playground.button@reset": 0 });
+		// .getNestedLocator({ body: 2, "body.section@playground": 1 });
 
-		expect(`${reset1}`).toEqual(
+		log.resetLogLevel();
+
+		expect(`${reset1}`).not.toEqual(
 			"locator('body').locator(locator('section')).filter({ hasText: /Playground/i }).filter({ hasText: /Primary Colors/i }).first().locator(getByRole('button', { name: 'Reset Color' })).filter({ hasText: /Reset/i }).filter({ hasText: /Color/i }).first()",
 		);
 

--- a/intTest/tests/with-options/locatorSchema/getNestedLocator.filter.spec.ts
+++ b/intTest/tests/with-options/locatorSchema/getNestedLocator.filter.spec.ts
@@ -63,7 +63,7 @@ test.describe("getNestedLocator for locatorSchema with filter property", () => {
 			.getLocatorSchema("fictional.filter@hasNotText.filter@hasText")
 			.update({ locatorMethod: GetByMethod.frameLocator });
 
-		expect(chainWithFilter.filter.hasText).toEqual("hasText");
+		expect.soft(chainWithFilter.filter.hasText).toEqual("hasText");
 
 		const chainedFrameLocator = await chainWithFilter.getNestedLocator();
 
@@ -101,9 +101,37 @@ test.describe("getNestedLocator for locatorSchema with filter property", () => {
 		);
 	});
 
-	test("filter with has: locatoasdasdr", async ({ testFilters }) => {
-		const reset = testFilters.getLocatorSchema("body.section@playground.button@reset");
+	test("filter with hasText", async ({ testFilters }) => {
+		await testFilters.page.goto(testFilters.fullUrl);
 
-		console.log(reset);
+		const playgroundRed = await testFilters.getNestedLocator("body.section@playground.button@red");
+		await playgroundRed.click();
+
+		const reset0 = await testFilters.getNestedLocator("body.section@playground.button@reset");
+
+		expect(`${reset0}`).toEqual(
+			"locator('body').locator(locator('section')).filter({ hasText: /Playground/i }).locator(getByRole('button', { name: 'Reset Color' }))",
+		);
+
+		const reset1 = await testFilters
+			.getLocatorSchema("body.section@playground.button@reset")
+			.addFilter("body.section@playground", { hasText: /Primary Colors/i })
+			.addFilter("body.section@playground.button@reset", { hasText: /Reset/i })
+			.addFilter("body.section@playground.button@reset", { hasText: /Color/i })
+			.getNestedLocator({ 1: 0, 2: 0 });
+
+		expect(`${reset1}`).toEqual(
+			"locator('body').locator(locator('section')).filter({ hasText: /Playground/i }).filter({ hasText: /Primary Colors/i }).first().locator(getByRole('button', { name: 'Reset Color' })).filter({ hasText: /Reset/i }).filter({ hasText: /Color/i }).first()",
+		);
+
+		const reset2 = await testFilters.getNestedLocator("body.section@playground.button@reset");
+
+		expect(`${reset2}`).toEqual(
+			"locator('body').locator(locator('section')).filter({ hasText: /Playground/i }).locator(getByRole('button', { name: 'Reset Color' }))",
+		);
+
+		await reset1.click();
+		await playgroundRed.click();
+		await reset2.click();
 	});
 });

--- a/intTest/tests/with-options/locatorSchema/getNestedLocator.filter.spec.ts
+++ b/intTest/tests/with-options/locatorSchema/getNestedLocator.filter.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "@fixtures/withOptions";
+import { GetByMethod } from "pomwright";
+
+test("given the same locatorSchemaPath, getNestedLocator should return the equvalent of manually chaining with getLocator", async ({
+	testPage,
+}) => {
+	const topMenu = await testPage.getLocator("topMenu");
+
+	const topMenuNotifications = topMenu.locator(await testPage.getLocator("topMenu.notifications"));
+
+	const topMenuNotificationsDropdown = topMenuNotifications.locator(
+		await testPage.getLocator("topMenu.notifications.dropdown"),
+	);
+
+	const topMenuNotificationsDropdownItem = topMenuNotificationsDropdown.locator(
+		await testPage.getLocator("topMenu.notifications.dropdown.item"),
+	);
+
+	expect(topMenuNotificationsDropdownItem).not.toBeNull();
+	expect(topMenuNotificationsDropdownItem).not.toBeUndefined();
+	expect(`${topMenuNotificationsDropdownItem}`).toEqual(
+		"locator('.w3-top').locator(locator('.w3-dropdown-hover')).locator(locator('.w3-dropdown-content')).locator(locator('.w3-bar-item'))",
+	);
+
+	const automaticallyChainedLocator = await testPage.getNestedLocator("topMenu.notifications.dropdown.item");
+	expect(automaticallyChainedLocator).not.toBeNull();
+	expect(automaticallyChainedLocator).not.toBeUndefined();
+	expect(`${automaticallyChainedLocator}`).toEqual(`${topMenuNotificationsDropdownItem}`);
+});
+
+test.describe("getNestedLocator for locatorSchema with filter property", () => {
+	type testCase = {
+		getByMethod: GetByMethod;
+		expected: string;
+	};
+
+	const testCases: testCase[] = [
+		{ getByMethod: GetByMethod.role, expected: "getByRole('button')" },
+		{ getByMethod: GetByMethod.text, expected: "getByText('text')" },
+		{ getByMethod: GetByMethod.label, expected: "getByLabel('label')" },
+		{ getByMethod: GetByMethod.placeholder, expected: "getByPlaceholder('placeholder')" },
+		{ getByMethod: GetByMethod.altText, expected: "getByAltText('altText')" },
+		{ getByMethod: GetByMethod.title, expected: "getByTitle('title')" },
+		{ getByMethod: GetByMethod.locator, expected: "locator('locator')" },
+		{ getByMethod: GetByMethod.dataCy, expected: "locator('data-cy=dataCy')" },
+		{ getByMethod: GetByMethod.testId, expected: "getByTestId('testId')" },
+		{ getByMethod: GetByMethod.id, expected: "locator('#id')" },
+	];
+
+	for (const { getByMethod, expected } of testCases) {
+		test(`GetByMethod.${getByMethod}: should apply filter `, async ({ testFilters }) => {
+			const undefinedFilter = await testFilters
+				.getLocatorSchema("fictional.filter@undefined")
+				.update({ locatorMethod: GetByMethod[getByMethod] })
+				.getNestedLocator();
+
+			expect(`${undefinedFilter}`).toEqual(expected);
+		});
+	}
+
+	test("GetByMethod.frameLocator: should NOT apply filter", async ({ testFilters }) => {
+		const chainWithFilter = testFilters
+			.getLocatorSchema("fictional.filter@hasNotText.filter@hasText")
+			.update({ locatorMethod: GetByMethod.frameLocator });
+
+		expect(chainWithFilter.filter.hasText).toEqual("hasText");
+
+		const chainedFrameLocator = await chainWithFilter.getNestedLocator();
+
+		expect(`${chainedFrameLocator}`).toEqual(
+			'internal:role=button[name="roleOptions"i] >> internal:has-not-text="hasNotText"i >> internal:chain=undefined',
+		);
+	});
+
+	test("multiple nesting/chaining", async ({ testFilters }) => {
+		const multiChainWithFilter = await testFilters
+			.getLocatorSchema("fictional.filter@hasNotText.filter@hasText.filter@hasNotText.filter@hasText")
+			.updates({
+				1: { locatorMethod: GetByMethod.role },
+				2: { locatorMethod: GetByMethod.locator },
+				3: { locatorMethod: GetByMethod.testId },
+				4: { locatorMethod: GetByMethod.label },
+			})
+			.getNestedLocator();
+
+		expect(`${multiChainWithFilter}`).toEqual(
+			"getByRole('button', { name: 'roleOptions' }).filter({ hasNotText: 'hasNotText' }).locator(locator('locator').filter({ hasText: 'locatorOptionsHasText' }).filter({ hasNotText: 'locatorOptionshasNotText' })).filter({ hasText: 'hasText' }).locator(getByTestId('testId')).filter({ hasNotText: 'hasNotText' }).locator(getByLabel('label', { exact: true })).filter({ hasText: 'hasText' })",
+		);
+	});
+
+	test("filter with has: locator", async ({ testFilters }) => {
+		const heading = await testFilters.getLocator("body.section.heading");
+
+		const multiChainWithFilter = await testFilters
+			.getLocatorSchema("fictional.filter@hasNotText")
+			.update({ locatorMethod: GetByMethod.role, filter: { has: heading } })
+			.getNestedLocator();
+
+		expect(`${multiChainWithFilter}`).toEqual(
+			"getByRole('button', { name: 'roleOptions' }).filter({ hasNotText: 'hasNotText' }).filter({ has: getByRole('heading', { level: 2 }) })",
+		);
+	});
+
+	test("filter with has: locatoasdasdr", async ({ testFilters }) => {
+		const reset = testFilters.getLocatorSchema("body.section@playground.button@reset");
+
+		console.log(reset);
+	});
+});

--- a/intTest/tests/with-options/locatorSchema/subPath.spec.ts
+++ b/intTest/tests/with-options/locatorSchema/subPath.spec.ts
@@ -1,0 +1,451 @@
+import { expect, test } from "@fixtures/withOptions";
+import { GetByMethod } from "pomwright";
+
+test.describe("getNestedLocator", () => {
+	const nth = ".nth(2)";
+	const nestedLocator =
+		"getByRole('button', { name: 'roleOptions' }).filter({ hasNotText: 'hasNotText' }).nth(2).locator(getByRole('button', { name: 'roleOptions' })).filter({ hasText: 'hasText' }).locator(getByRole('button', { name: 'roleOptions' })).filter({ hasNotText: 'hasNotText' }).locator(getByRole('button', { name: 'roleOptions' })).filter({ hasText: 'hasText' })";
+
+	test("await poc.getNestedLocator(LocatorSchemaPath, {subPath: nth})", async ({ testFilters }) => {
+		const t = await testFilters.getNestedLocator(
+			"fictional.filter@hasNotText.filter@hasText.filter@hasNotText.filter@hasText",
+			{ "fictional.filter@hasNotText": 2 },
+		);
+
+		expect(`${t}`).toContain(nth);
+
+		expect(`${t}`).toEqual(nestedLocator);
+	});
+
+	test("await poc.getLocatorSchema(LocatorSchemaPath).getNestedLocator({subPath: nth})", async ({ testFilters }) => {
+		const t = await testFilters
+			.getLocatorSchema("fictional.filter@hasNotText.filter@hasText.filter@hasNotText.filter@hasText")
+			.getNestedLocator({ "fictional.filter@hasNotText": 2 });
+
+		expect(`${t}`).toContain(nth);
+
+		expect(`${t}`).toEqual(nestedLocator);
+	});
+
+	test("deprecated await poc.getNestedLocator(LocatorSchemaPath, {indexOfPath: nth})", async ({ testFilters }) => {
+		const t = await testFilters.getNestedLocator(
+			"fictional.filter@hasNotText.filter@hasText.filter@hasNotText.filter@hasText",
+			{ 1: 2 },
+		);
+
+		expect(`${t}`).toContain(nth);
+
+		expect(`${t}`).toEqual(nestedLocator);
+	});
+
+	test("deprecated await poc.getLocatorSchema(LocatorSchemaPath).getNestedLocator({indexOfPath: nth})", async ({
+		testFilters,
+	}) => {
+		const t = await testFilters
+			.getLocatorSchema("fictional.filter@hasNotText.filter@hasText.filter@hasNotText.filter@hasText")
+			.getNestedLocator({ 1: 2 });
+
+		expect(`${t}`).toContain(nth);
+
+		expect(`${t}`).toEqual(nestedLocator);
+	});
+
+	test("await poc.getLocatorSchema(LocatorSchemaPath).getNestedLocator({invalidSubPath: nth})", async ({
+		testFilters,
+	}) => {
+		await expect(async () => {
+			await testFilters
+				.getLocatorSchema("fictional.filter@hasNotText.filter@hasText.filter@hasNotText.filter@hasText")
+				.getNestedLocator({ "fictional.filter@has": 2 });
+		}).rejects.toThrowError(
+			/Invalid sub-path 'fictional\.filter@has' in getNestedLocator\. Allowed sub-paths are:\s*fictional\.filter@hasNotText\.filter@hasText\.filter@hasNotText\.filter@hasText,\s*fictional\.filter@hasNotText,\s*fictional\.filter@hasNotText\.filter@hasText,\s*fictional\.filter@hasNotText\.filter@hasText\.filter@hasNotText/,
+		);
+	});
+
+	test("await poc.getLocatorSchema(LocatorSchemaPath).getNestedLocator({noneExistantSubPath: nth})", async ({
+		testFilters,
+	}) => {
+		await expect(async () => {
+			await testFilters
+				.getLocatorSchema("fictional.filter@hasNotText.filter@hasText.filter@hasNotText.filter@hasText")
+				.getNestedLocator({ fictional: 2 });
+		}).rejects.toThrowError(
+			/Invalid sub-path 'fictional' in getNestedLocator\. Allowed sub-paths are:\s*fictional\.filter@hasNotText\.filter@hasText\.filter@hasNotText\.filter@hasText,\s*fictional\.filter@hasNotText,\s*fictional\.filter@hasNotText\.filter@hasText,\s*fictional\.filter@hasNotText\.filter@hasText\.filter@hasNotText/,
+		);
+	});
+
+	test("await poc.getNestedLocator(LocatorSchemaPath, {invalidSubPath: nth})", async ({ testFilters }) => {
+		await expect(async () => {
+			await testFilters.getNestedLocator(
+				"fictional.filter@hasNotText.filter@hasText.filter@hasNotText.filter@hasText",
+				{ "fictional.filter@has": 2 },
+			);
+		}).rejects.toThrowError(
+			/Invalid sub-path 'fictional\.filter@has' in getNestedLocator\. Allowed sub-paths are:\s*fictional\.filter@hasNotText\.filter@hasText\.filter@hasNotText\.filter@hasText,\s*fictional\.filter@hasNotText,\s*fictional\.filter@hasNotText\.filter@hasText,\s*fictional\.filter@hasNotText\.filter@hasText\.filter@hasNotText/,
+		);
+	});
+
+	test("await poc.getLocatorSchema(LocatorSchemaPath).getNestedLocator({subPath: -1})", async ({ testFilters }) => {
+		await expect(async () => {
+			await testFilters
+				.getLocatorSchema("fictional.filter@hasNotText.filter@hasText.filter@hasNotText.filter@hasText")
+				.getNestedLocator({ "fictional.filter@hasNotText": -1 });
+		}).rejects.toThrowError(
+			"Invalid index for sub-path 'fictional.filter@hasNotText': Expected a positive number or null.",
+		);
+	});
+});
+
+test.describe("update, deprecated update & deprecated updates", () => {
+	test("await poc.getLocatorSchema(LocatorSchemaPath).update(subPath, updates)", async ({ testFilters }) => {
+		const preUpdate = testFilters.getLocatorSchema("body.section");
+
+		expect(preUpdate.locatorMethod).not.toEqual(GetByMethod.role);
+		expect(preUpdate.role).not.toEqual("button");
+		expect(preUpdate.roleOptions).not.toEqual({ name: "Click me!" });
+
+		const newUpdate = testFilters.getLocatorSchema("body.section").update("body.section", {
+			locatorMethod: GetByMethod.testId,
+			testId: "someTestId",
+		});
+
+		expect(newUpdate.locatorMethod).toEqual(GetByMethod.testId);
+		expect(newUpdate.role).not.toEqual("button");
+		expect(newUpdate.testId).toEqual("someTestId");
+		expect(newUpdate.roleOptions).not.toEqual({ name: "Click me!" });
+
+		const postUpdate = preUpdate.update("body.section", {
+			locatorMethod: GetByMethod.role,
+			role: "button",
+			roleOptions: { name: "Click me!" },
+		});
+
+		expect(postUpdate.locatorMethod).toEqual(GetByMethod.role);
+		expect(postUpdate.role).toEqual("button");
+		expect(postUpdate.testId).not.toEqual("someTestId");
+		expect(postUpdate.roleOptions).toEqual({ name: "Click me!" });
+	});
+
+	test("chainable .update(subPath, updates)", async ({ testFilters }) => {
+		const preUpdate = testFilters.getLocatorSchema("body.section");
+
+		expect(preUpdate.schemasMap.get("body").locator).toBe("body");
+		expect(preUpdate.locatorMethod).not.toEqual(GetByMethod.role);
+		expect(preUpdate.role).not.toEqual("button");
+		expect(preUpdate.roleOptions).not.toEqual({ name: "Click me!" });
+
+		const multiUpdate = preUpdate
+			.update("body", {
+				locator: "SOMEBODY",
+			})
+			.update("body.section", {
+				locatorMethod: GetByMethod.role,
+			})
+			.update("body.section", {
+				role: "button",
+			})
+			.update("body.section", {
+				roleOptions: { name: "Click me!" },
+			});
+
+		expect(preUpdate.schemasMap.get("body").locator).toBe("SOMEBODY");
+		expect(multiUpdate.locatorMethod).toEqual(GetByMethod.role);
+		expect(multiUpdate.role).toEqual("button");
+		expect(multiUpdate.testId).not.toEqual("someTestId");
+		expect(multiUpdate.roleOptions).toEqual({ name: "Click me!" });
+	});
+
+	test(".update(subPath, updates) successfully merges", async ({ testFilters }) => {
+		const preUpdate = testFilters.getLocatorSchema("body.section.heading");
+
+		expect(preUpdate.role).toEqual("heading");
+		expect(preUpdate.roleOptions).toEqual({ level: 2 });
+		expect(preUpdate.locatorMethod).toEqual(GetByMethod.role);
+
+		const merged = preUpdate.update("body.section.heading", {
+			roleOptions: { name: "HEADING TEXT" },
+		});
+
+		expect(merged.role).toEqual("heading");
+		expect(merged.roleOptions).toEqual({ name: "HEADING TEXT", level: 2 });
+		expect(merged.locatorMethod).toEqual(GetByMethod.role);
+	});
+
+	test("deprecated await poc.getLocatorSchema(LocatorSchemaPath).update(updates)", async ({ testFilters }) => {
+		const preUpdate = testFilters.getLocatorSchema("body.section");
+
+		expect(preUpdate.locatorMethod).not.toEqual(GetByMethod.role);
+		expect(preUpdate.role).not.toEqual("button");
+		expect(preUpdate.roleOptions).not.toEqual({ name: "Click me!" });
+
+		const newUpdate = testFilters.getLocatorSchema("body.section").update({
+			locatorMethod: GetByMethod.testId,
+			testId: "someTestId",
+		});
+
+		expect(newUpdate.locatorMethod).toEqual(GetByMethod.testId);
+		expect(newUpdate.role).not.toEqual("button");
+		expect(newUpdate.testId).toEqual("someTestId");
+		expect(newUpdate.roleOptions).not.toEqual({ name: "Click me!" });
+
+		const postUpdate = preUpdate.update({
+			locatorMethod: GetByMethod.role,
+			role: "button",
+			roleOptions: { name: "Click me!" },
+		});
+
+		expect(postUpdate.locatorMethod).toEqual(GetByMethod.role);
+		expect(postUpdate.role).toEqual("button");
+		expect(postUpdate.testId).not.toEqual("someTestId");
+		expect(postUpdate.roleOptions).toEqual({ name: "Click me!" });
+	});
+
+	test("deprecated chainable .update(updates)", async ({ testFilters }) => {
+		const preUpdate = testFilters.getLocatorSchema("body.section");
+
+		expect(preUpdate.locatorMethod).not.toEqual(GetByMethod.role);
+		expect(preUpdate.role).not.toEqual("button");
+		expect(preUpdate.roleOptions).not.toEqual({ name: "Click me!" });
+
+		const multiUpdate = preUpdate
+			.update({
+				locatorMethod: GetByMethod.role,
+			})
+			.update({
+				role: "button",
+			})
+			.update({
+				roleOptions: { name: "Click me!" },
+			});
+
+		expect(multiUpdate.locatorMethod).toEqual(GetByMethod.role);
+		expect(multiUpdate.role).toEqual("button");
+		expect(multiUpdate.testId).not.toEqual("someTestId");
+		expect(multiUpdate.roleOptions).toEqual({ name: "Click me!" });
+	});
+
+	test("deprecated .update(updates) successfully merges", async ({ testFilters }) => {
+		const preUpdate = testFilters.getLocatorSchema("body.section.heading");
+
+		expect(preUpdate.role).toEqual("heading");
+		expect(preUpdate.roleOptions).toEqual({ level: 2 });
+		expect(preUpdate.locatorMethod).toEqual(GetByMethod.role);
+
+		const merged = preUpdate.update({
+			roleOptions: { name: "HEADING TEXT" },
+		});
+
+		expect(merged.role).toEqual("heading");
+		expect(merged.roleOptions).toEqual({ name: "HEADING TEXT", level: 2 });
+		expect(merged.locatorMethod).toEqual(GetByMethod.role);
+	});
+
+	test("deprecated await poc.getLocatorSchema(LocatorSchemaPath).updates({indexOfPath: updates})", async ({
+		testFilters,
+	}) => {
+		const preUpdate = testFilters.getLocatorSchema("body.section");
+
+		expect(preUpdate.locatorMethod).not.toEqual(GetByMethod.role);
+		expect(preUpdate.role).not.toEqual("button");
+		expect(preUpdate.roleOptions).not.toEqual({ name: "Click me!" });
+
+		const newUpdate = testFilters.getLocatorSchema("body.section").updates({
+			1: {
+				locatorMethod: GetByMethod.testId,
+				testId: "someTestId",
+			},
+		});
+
+		expect(newUpdate.locatorMethod).toEqual(GetByMethod.testId);
+		expect(newUpdate.role).not.toEqual("button");
+		expect(newUpdate.testId).toEqual("someTestId");
+		expect(newUpdate.roleOptions).not.toEqual({ name: "Click me!" });
+
+		const postUpdate = preUpdate.updates({
+			1: {
+				locatorMethod: GetByMethod.role,
+				role: "button",
+				roleOptions: { name: "Click me!" },
+			},
+		});
+
+		expect(postUpdate.locatorMethod).toEqual(GetByMethod.role);
+		expect(postUpdate.role).toEqual("button");
+		expect(postUpdate.testId).not.toEqual("someTestId");
+		expect(postUpdate.roleOptions).toEqual({ name: "Click me!" });
+	});
+
+	test("deprecated chainable .updates({indexOfPath: updates, ...})", async ({ testFilters }) => {
+		const preUpdate = testFilters.getLocatorSchema("body.section");
+
+		expect(preUpdate.schemasMap.get("body").locator).toBe("body");
+		expect(preUpdate.locatorMethod).not.toEqual(GetByMethod.role);
+		expect(preUpdate.role).not.toEqual("button");
+		expect(preUpdate.roleOptions).not.toEqual({ name: "Click me!" });
+
+		const multiUpdate = preUpdate
+			.updates({
+				"0": {
+					locator: "SOMEBODY",
+				},
+			})
+			.updates({
+				1: {
+					locatorMethod: GetByMethod.role,
+				},
+			})
+			.updates({
+				1: {
+					role: "button",
+					roleOptions: { name: "Click me!" },
+				},
+			});
+
+		expect(preUpdate.schemasMap.get("body").locator).toBe("SOMEBODY");
+		expect(multiUpdate.locatorMethod).toEqual(GetByMethod.role);
+		expect(multiUpdate.role).toEqual("button");
+		expect(multiUpdate.testId).not.toEqual("someTestId");
+		expect(multiUpdate.roleOptions).toEqual({ name: "Click me!" });
+	});
+
+	test("deprecated .updates({indexOfPath: updates}) successfully merges", async ({ testFilters }) => {
+		const preUpdate = testFilters.getLocatorSchema("body.section.heading");
+
+		expect(preUpdate.role).toEqual("heading");
+		expect(preUpdate.roleOptions).toEqual({ level: 2 });
+		expect(preUpdate.locatorMethod).toEqual(GetByMethod.role);
+
+		const merged = preUpdate.updates({
+			2: {
+				roleOptions: { name: "HEADING TEXT" },
+			},
+		});
+
+		expect(merged.role).toEqual("heading");
+		expect(merged.roleOptions).toEqual({ name: "HEADING TEXT", level: 2 });
+		expect(merged.locatorMethod).toEqual(GetByMethod.role);
+	});
+
+	test("update, deprecated update & deprecated updates produce the same result", async ({ testFilters }) => {
+		const update = testFilters.getLocatorSchema("body.section.heading");
+		expect(update.role).toEqual("heading");
+		expect(update.roleOptions).toEqual({ level: 2 });
+		expect(update.locatorMethod).toEqual(GetByMethod.role);
+
+		update.update("body.section.heading", { roleOptions: { name: "HEADING TEXT" } });
+
+		const deprecatedUpdate = testFilters.getLocatorSchema("body.section.heading");
+		expect(deprecatedUpdate.role).toEqual("heading");
+		expect(deprecatedUpdate.roleOptions).toEqual({ level: 2 });
+		expect(deprecatedUpdate.locatorMethod).toEqual(GetByMethod.role);
+
+		deprecatedUpdate.update({ roleOptions: { name: "HEADING TEXT" } });
+
+		const deprecatedUpdates = testFilters.getLocatorSchema("body.section.heading");
+		expect(deprecatedUpdates.role).toEqual("heading");
+		expect(deprecatedUpdates.roleOptions).toEqual({ level: 2 });
+		expect(deprecatedUpdates.locatorMethod).toEqual(GetByMethod.role);
+
+		deprecatedUpdate.updates({ 2: { roleOptions: { name: "HEADING TEXT" } } });
+
+		expect(`${update}`).toEqual(`${deprecatedUpdate}`);
+		expect(`${update}`).toEqual(`${deprecatedUpdates}`);
+		expect(`${deprecatedUpdate}`).toEqual(`${deprecatedUpdates}`);
+
+		expect(update).not.toEqual(deprecatedUpdate);
+		expect(update).not.toEqual(deprecatedUpdates);
+		expect(deprecatedUpdate).not.toEqual(deprecatedUpdates);
+
+		const updateNestedLocator = update.getNestedLocator();
+		const deprecatedUpdateNestedLocator = deprecatedUpdate.getNestedLocator();
+		const deprecatedUpdatesNestedLocator = deprecatedUpdates.getNestedLocator();
+
+		expect(`${updateNestedLocator}`).toEqual(`${deprecatedUpdateNestedLocator}`);
+		expect(`${updateNestedLocator}`).toEqual(`${deprecatedUpdatesNestedLocator}`);
+		expect(`${deprecatedUpdateNestedLocator}`).toEqual(`${deprecatedUpdatesNestedLocator}`);
+
+		expect(updateNestedLocator).not.toEqual(deprecatedUpdateNestedLocator);
+		expect(updateNestedLocator).not.toEqual(deprecatedUpdatesNestedLocator);
+		expect(deprecatedUpdateNestedLocator).not.toEqual(deprecatedUpdatesNestedLocator);
+	});
+});
+
+test.describe("addFilter", () => {
+	test("await poc.getLocatorSchema(LocatorSchemaPath).addFilter(subPath, filterValue)", async ({ testFilters }) => {
+		const preFilter = testFilters.getLocatorSchema("body.section");
+
+		expect(preFilter.filterMap.size).toBe(0);
+
+		const postFilter = preFilter.addFilter("body.section", { hasText: "Playground" });
+
+		expect(postFilter.filterMap.get("body.section")).toEqual([{ hasText: "Playground" }]);
+
+		const newFilter = testFilters.getLocatorSchema("body.section");
+		expect(newFilter.filterMap.size).toBe(0);
+	});
+
+	test("chainable .addFilter(subPath, filterValue)", async ({ testFilters }) => {
+		const preFilter = testFilters.getLocatorSchema("body.section");
+
+		const locator = await preFilter.getLocator();
+
+		expect(preFilter.filterMap.size).toBe(0);
+
+		const postFilter = preFilter
+			.addFilter("body", { has: locator })
+			.addFilter("body.section", { hasText: "Dude... Green is not a primary color." })
+			.addFilter("body.section", { hasText: "Playground" });
+
+		expect(postFilter.filterMap).toEqual(
+			new Map([
+				[
+					"body",
+					[
+						{
+							has: {
+								_frame: expect.objectContaining({
+									_guid: expect.any(String),
+									_type: "Frame",
+								}),
+								_selector: "section",
+							},
+						},
+					],
+				],
+				["body.section", [{ hasText: "Dude... Green is not a primary color." }, { hasText: "Playground" }]],
+			]),
+		);
+
+		const newFilter = testFilters.getLocatorSchema("body.section");
+		expect(newFilter.filterMap.size).toBe(0);
+
+		const NestedLocatorWithFilter = await postFilter.getNestedLocator();
+		expect(`${NestedLocatorWithFilter}`).toEqual(
+			"locator('body').filter({ has: locator('section') }).locator(locator('section')).filter({ hasText: 'Dude... Green is not a primary color.' }).filter({ hasText: 'Playground' })",
+		);
+	});
+
+	test("await poc.getLocatorSchema(LocatorSchemaPath).addFilter(invalidSubPath, filterValue)", async ({
+		testFilters,
+	}) => {
+		expect(async () => {
+			testFilters
+				.getLocatorSchema("fictional.filter@hasNotText.filter@hasText.filter@hasNotText.filter@hasText")
+				.addFilter("fictional.filter@has", { hasText: "something" });
+		}).rejects.toThrowError(
+			/Invalid sub-path 'fictional\.filter@has' in addFilter\. Allowed sub-paths are:\s*fictional\.filter@hasNotText,\s*fictional\.filter@hasNotText\.filter@hasText,\s*fictional\.filter@hasNotText\.filter@hasText\.filter@hasNotText,\s*fictional\.filter@hasNotText\.filter@hasText\.filter@hasNotText\.filter@hasText/,
+		);
+	});
+
+	test("await poc.getLocatorSchema(LocatorSchemaPath).addFilter(noneExistantSubPath, filterValue)", async ({
+		testFilters,
+	}) => {
+		expect(async () => {
+			testFilters
+				.getLocatorSchema("fictional.filter@hasNotText.filter@hasText.filter@hasNotText.filter@hasText")
+				.addFilter("fictional", { hasText: "something" });
+		}).rejects.toThrowError(
+			/Invalid sub-path 'fictional' in addFilter\. Allowed sub-paths are:\s*fictional\.filter@hasNotText,\s*fictional\.filter@hasNotText\.filter@hasText,\s*fictional\.filter@hasNotText\.filter@hasText\.filter@hasNotText,\s*fictional\.filter@hasNotText\.filter@hasText\.filter@hasNotText\.filter@hasText/,
+		);
+	});
+});

--- a/intTest/tests/with-options/testFilters.spec.ts
+++ b/intTest/tests/with-options/testFilters.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "@fixtures/withOptions";
+
+test("locatorSchema filter property should function", async ({ testFilters }) => {
+	await testFilters.page.goto(testFilters.fullUrl);
+
+	const playgroundSection = await testFilters.getNestedLocator("body.section@playground");
+	// await expect(playgroundSection).not.toHaveCSS("background-color", "red");
+
+	const playgroundBtnRed = await testFilters.getNestedLocator("body.section@playground.button@red");
+	await playgroundBtnRed.click();
+	await expect(playgroundSection).toHaveCSS("background-color", "rgb(255, 0, 0)");
+});

--- a/package.json
+++ b/package.json
@@ -56,5 +56,6 @@
 	},
 	"peerDependencies": {
 		"@playwright/test": ">=1.41.0 <1.42.0 || >=1.43.0 <2.0.0"
-	}
+	},
+	"packageManager": "pnpm@9.12.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,51 +1,1529 @@
-lockfileVersion: '6.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  '@playwright/test':
-    specifier: '>=1.41.0 <1.42.0 || >=1.43.0 <2.0.0'
-    version: 1.47.1
+importers:
 
-devDependencies:
-  '@biomejs/biome':
-    specifier: ^1.9.2
-    version: 1.9.2
-  '@changesets/changelog-github':
-    specifier: ^0.5.0
-    version: 0.5.0
-  '@changesets/cli':
-    specifier: ^2.27.8
-    version: 2.27.8
-  '@types/node':
-    specifier: ^20.16.6
-    version: 20.16.6
-  tsup:
-    specifier: ^8.3.0
-    version: 8.3.0(typescript@5.6.2)
-  typescript:
-    specifier: ^5.6.2
-    version: 5.6.2
-  vitest:
-    specifier: ^2.1.1
-    version: 2.1.1(@types/node@20.16.6)
+  .:
+    dependencies:
+      '@playwright/test':
+        specifier: '>=1.41.0 <1.42.0 || >=1.43.0 <2.0.0'
+        version: 1.47.1
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^1.9.2
+        version: 1.9.2
+      '@changesets/changelog-github':
+        specifier: ^0.5.0
+        version: 0.5.0
+      '@changesets/cli':
+        specifier: ^2.27.8
+        version: 2.27.8
+      '@types/node':
+        specifier: ^20.16.6
+        version: 20.16.6
+      tsup:
+        specifier: ^8.3.0
+        version: 8.3.0(typescript@5.6.2)
+      typescript:
+        specifier: ^5.6.2
+        version: 5.6.2
+      vitest:
+        specifier: ^2.1.1
+        version: 2.1.1(@types/node@20.16.6)
 
 packages:
 
-  /@babel/runtime@7.23.8:
+  '@babel/runtime@7.23.8':
     resolution: {integrity: sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      regenerator-runtime: 0.14.1
-    dev: true
 
-  /@biomejs/biome@1.9.2:
+  '@biomejs/biome@1.9.2':
     resolution: {integrity: sha512-4j2Gfwft8Jqp1X0qLYvK4TEy4xhTo4o6rlvJPsjPeEame8gsmbGQfOPBkw7ur+7/Z/f0HZmCZKqbMvR7vTXQYQ==}
     engines: {node: '>=14.21.3'}
     hasBin: true
-    requiresBuild: true
+
+  '@biomejs/cli-darwin-arm64@1.9.2':
+    resolution: {integrity: sha512-rbs9uJHFmhqB3Td0Ro+1wmeZOHhAPTL3WHr8NtaVczUmDhXkRDWScaxicG9+vhSLj1iLrW47itiK6xiIJy6vaA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@1.9.2':
+    resolution: {integrity: sha512-BlfULKijNaMigQ9GH9fqJVt+3JTDOSiZeWOQtG/1S1sa8Lp046JHG3wRJVOvekTPL9q/CNFW1NVG8J0JN+L1OA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@1.9.2':
+    resolution: {integrity: sha512-ZATvbUWhNxegSALUnCKWqetTZqrK72r2RsFD19OK5jXDj/7o1hzI1KzDNG78LloZxftrwr3uI9SqCLh06shSZw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@1.9.2':
+    resolution: {integrity: sha512-T8TJuSxuBDeQCQzxZu2o3OU4eyLumTofhCxxFd3+aH2AEWVMnH7Z/c3QP1lHI5RRMBP9xIJeMORqDQ5j+gVZzw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@1.9.2':
+    resolution: {integrity: sha512-CjPM6jT1miV5pry9C7qv8YJk0FIZvZd86QRD3atvDgfgeh9WQU0k2Aoo0xUcPdTnoz0WNwRtDicHxwik63MmSg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@1.9.2':
+    resolution: {integrity: sha512-T0cPk3C3Jr2pVlsuQVTBqk2qPjTm8cYcTD9p/wmR9MeVqui1C/xTVfOIwd3miRODFMrJaVQ8MYSXnVIhV9jTjg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@1.9.2':
+    resolution: {integrity: sha512-2x7gSty75bNIeD23ZRPXyox6Z/V0M71ObeJtvQBhi1fgrvPdtkEuw7/0wEHg6buNCubzOFuN9WYJm6FKoUHfhg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.9.2':
+    resolution: {integrity: sha512-JC3XvdYcjmu1FmAehVwVV0SebLpeNTnO2ZaMdGCSOdS7f8O9Fq14T2P1gTG1Q29Q8Dt1S03hh0IdVpIZykOL8g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
+  '@changesets/apply-release-plan@7.0.5':
+    resolution: {integrity: sha512-1cWCk+ZshEkSVEZrm2fSj1Gz8sYvxgUL4Q78+1ZZqeqfuevPTPk033/yUZ3df8BKMohkqqHfzj0HOOrG0KtXTw==}
+
+  '@changesets/assemble-release-plan@6.0.4':
+    resolution: {integrity: sha512-nqICnvmrwWj4w2x0fOhVj2QEGdlUuwVAwESrUo5HLzWMI1rE5SWfsr9ln+rDqWB6RQ2ZyaMZHUcU7/IRaUJS+Q==}
+
+  '@changesets/changelog-git@0.2.0':
+    resolution: {integrity: sha512-bHOx97iFI4OClIT35Lok3sJAwM31VbUM++gnMBV16fdbtBhgYu4dxsphBF/0AZZsyAHMrnM0yFcj5gZM1py6uQ==}
+
+  '@changesets/changelog-github@0.5.0':
+    resolution: {integrity: sha512-zoeq2LJJVcPJcIotHRJEEA2qCqX0AQIeFE+L21L8sRLPVqDhSXY8ZWAt2sohtBpFZkBwu+LUwMSKRr2lMy3LJA==}
+
+  '@changesets/cli@2.27.8':
+    resolution: {integrity: sha512-gZNyh+LdSsI82wBSHLQ3QN5J30P4uHKJ4fXgoGwQxfXwYFTJzDdvIJasZn8rYQtmKhyQuiBj4SSnLuKlxKWq4w==}
+    hasBin: true
+
+  '@changesets/config@3.0.3':
+    resolution: {integrity: sha512-vqgQZMyIcuIpw9nqFIpTSNyc/wgm/Lu1zKN5vECy74u95Qx/Wa9g27HdgO4NkVAaq+BGA8wUc/qvbvVNs93n6A==}
+
+  '@changesets/errors@0.2.0':
+    resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
+
+  '@changesets/get-dependents-graph@2.1.2':
+    resolution: {integrity: sha512-sgcHRkiBY9i4zWYBwlVyAjEM9sAzs4wYVwJUdnbDLnVG3QwAaia1Mk5P8M7kraTOZN+vBET7n8KyB0YXCbFRLQ==}
+
+  '@changesets/get-github-info@0.6.0':
+    resolution: {integrity: sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==}
+
+  '@changesets/get-release-plan@4.0.4':
+    resolution: {integrity: sha512-SicG/S67JmPTrdcc9Vpu0wSQt7IiuN0dc8iR5VScnnTVPfIaLvKmEGRvIaF0kcn8u5ZqLbormZNTO77bCEvyWw==}
+
+  '@changesets/get-version-range-type@0.4.0':
+    resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
+
+  '@changesets/git@3.0.1':
+    resolution: {integrity: sha512-pdgHcYBLCPcLd82aRcuO0kxCDbw/yISlOtkmwmE8Odo1L6hSiZrBOsRl84eYG7DRCab/iHnOkWqExqc4wxk2LQ==}
+
+  '@changesets/logger@0.1.1':
+    resolution: {integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==}
+
+  '@changesets/parse@0.4.0':
+    resolution: {integrity: sha512-TS/9KG2CdGXS27S+QxbZXgr8uPsP4yNJYb4BC2/NeFUj80Rni3TeD2qwWmabymxmrLo7JEsytXH1FbpKTbvivw==}
+
+  '@changesets/pre@2.0.1':
+    resolution: {integrity: sha512-vvBJ/If4jKM4tPz9JdY2kGOgWmCowUYOi5Ycv8dyLnEE8FgpYYUo1mgJZxcdtGGP3aG8rAQulGLyyXGSLkIMTQ==}
+
+  '@changesets/read@0.6.1':
+    resolution: {integrity: sha512-jYMbyXQk3nwP25nRzQQGa1nKLY0KfoOV7VLgwucI0bUO8t8ZLCr6LZmgjXsiKuRDc+5A6doKPr9w2d+FEJ55zQ==}
+
+  '@changesets/should-skip-package@0.1.1':
+    resolution: {integrity: sha512-H9LjLbF6mMHLtJIc/eHR9Na+MifJ3VxtgP/Y+XLn4BF7tDTEN1HNYtH6QMcjP1uxp9sjaFYmW8xqloaCi/ckTg==}
+
+  '@changesets/types@4.1.0':
+    resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
+
+  '@changesets/types@6.0.0':
+    resolution: {integrity: sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==}
+
+  '@changesets/write@0.3.2':
+    resolution: {integrity: sha512-kDxDrPNpUgsjDbWBvUo27PzKX4gqeKOlhibaOXDJA6kuBisGqNHv/HwGJrAu8U/dSf8ZEFIeHIPtvSlZI1kULw==}
+
+  '@esbuild/aix-ppc64@0.20.2':
+    resolution: {integrity: sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.23.1':
+    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.20.2':
+    resolution: {integrity: sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.23.1':
+    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.20.2':
+    resolution: {integrity: sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.23.1':
+    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.20.2':
+    resolution: {integrity: sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.23.1':
+    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.20.2':
+    resolution: {integrity: sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.23.1':
+    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.20.2':
+    resolution: {integrity: sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.23.1':
+    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.20.2':
+    resolution: {integrity: sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.23.1':
+    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.20.2':
+    resolution: {integrity: sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.23.1':
+    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.20.2':
+    resolution: {integrity: sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.23.1':
+    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.20.2':
+    resolution: {integrity: sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.23.1':
+    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.20.2':
+    resolution: {integrity: sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.23.1':
+    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.20.2':
+    resolution: {integrity: sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.23.1':
+    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.20.2':
+    resolution: {integrity: sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.23.1':
+    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.20.2':
+    resolution: {integrity: sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.23.1':
+    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.20.2':
+    resolution: {integrity: sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.23.1':
+    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.20.2':
+    resolution: {integrity: sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.23.1':
+    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.20.2':
+    resolution: {integrity: sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.23.1':
+    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.20.2':
+    resolution: {integrity: sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.23.1':
+    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.20.2':
+    resolution: {integrity: sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.20.2':
+    resolution: {integrity: sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.23.1':
+    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.20.2':
+    resolution: {integrity: sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.23.1':
+    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.20.2':
+    resolution: {integrity: sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.23.1':
+    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.20.2':
+    resolution: {integrity: sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.23.1':
+    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@jridgewell/gen-mapping@0.3.3':
+    resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/resolve-uri@3.1.1':
+    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/set-array@1.1.2':
+    resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.4.15':
+    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+
+  '@jridgewell/sourcemap-codec@1.5.0':
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
+  '@jridgewell/trace-mapping@0.3.20':
+    resolution: {integrity: sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==}
+
+  '@manypkg/find-root@1.1.0':
+    resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
+
+  '@manypkg/get-packages@1.1.3':
+    resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@playwright/test@1.47.1':
+    resolution: {integrity: sha512-dbWpcNQZ5nj16m+A5UNScYx7HX5trIy7g4phrcitn+Nk83S32EBX/CLU4hiF4RGKX/yRc93AAqtfaXB7JWBd4Q==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@rollup/rollup-android-arm-eabi@4.14.1':
+    resolution: {integrity: sha512-fH8/o8nSUek8ceQnT7K4EQbSiV7jgkHq81m9lWZFIXjJ7lJzpWXbQFpT/Zh6OZYnpFykvzC3fbEvEAFZu03dPA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm-eabi@4.22.4':
+    resolution: {integrity: sha512-Fxamp4aEZnfPOcGA8KSNEohV8hX7zVHOemC8jVBoBUHu5zpJK/Eu3uJwt6BMgy9fkvzxDaurgj96F/NiLukF2w==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.14.1':
+    resolution: {integrity: sha512-Y/9OHLjzkunF+KGEoJr3heiD5X9OLa8sbT1lm0NYeKyaM3oMhhQFvPB0bNZYJwlq93j8Z6wSxh9+cyKQaxS7PQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.22.4':
+    resolution: {integrity: sha512-VXoK5UMrgECLYaMuGuVTOx5kcuap1Jm8g/M83RnCHBKOqvPPmROFJGQaZhGccnsFtfXQ3XYa4/jMCJvZnbJBdA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.14.1':
+    resolution: {integrity: sha512-+kecg3FY84WadgcuSVm6llrABOdQAEbNdnpi5X3UwWiFVhZIZvKgGrF7kmLguvxHNQy+UuRV66cLVl3S+Rkt+Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-arm64@4.22.4':
+    resolution: {integrity: sha512-xMM9ORBqu81jyMKCDP+SZDhnX2QEVQzTcC6G18KlTQEzWK8r/oNZtKuZaCcHhnsa6fEeOBionoyl5JsAbE/36Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.14.1':
+    resolution: {integrity: sha512-2pYRzEjVqq2TB/UNv47BV/8vQiXkFGVmPFwJb+1E0IFFZbIX8/jo1olxqqMbo6xCXf8kabANhp5bzCij2tFLUA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.22.4':
+    resolution: {integrity: sha512-aJJyYKQwbHuhTUrjWjxEvGnNNBCnmpHDvrb8JFDbeSH3m2XdHcxDd3jthAzvmoI8w/kSjd2y0udT+4okADsZIw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.14.1':
+    resolution: {integrity: sha512-mS6wQ6Do6/wmrF9aTFVpIJ3/IDXhg1EZcQFYHZLHqw6AzMBjTHWnCG35HxSqUNphh0EHqSM6wRTT8HsL1C0x5g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.22.4':
+    resolution: {integrity: sha512-j63YtCIRAzbO+gC2L9dWXRh5BFetsv0j0va0Wi9epXDgU/XUi5dJKo4USTttVyK7fGw2nPWK0PbAvyliz50SCQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.22.4':
+    resolution: {integrity: sha512-dJnWUgwWBX1YBRsuKKMOlXCzh2Wu1mlHzv20TpqEsfdZLb3WoJW2kIEsGwLkroYf24IrPAvOT/ZQ2OYMV6vlrg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.14.1':
+    resolution: {integrity: sha512-p9rGKYkHdFMzhckOTFubfxgyIO1vw//7IIjBBRVzyZebWlzRLeNhqxuSaZ7kCEKVkm/kuC9fVRW9HkC/zNRG2w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.22.4':
+    resolution: {integrity: sha512-AdPRoNi3NKVLolCN/Sp4F4N1d98c4SBnHMKoLuiG6RXgoZ4sllseuGioszumnPGmPM2O7qaAX/IJdeDU8f26Aw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.14.1':
+    resolution: {integrity: sha512-nDY6Yz5xS/Y4M2i9JLQd3Rofh5OR8Bn8qe3Mv/qCVpHFlwtZSBYSPaU4mrGazWkXrdQ98GB//H0BirGR/SKFSw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.22.4':
+    resolution: {integrity: sha512-Gl0AxBtDg8uoAn5CCqQDMqAx22Wx22pjDOjBdmG0VIWX3qUBHzYmOKh8KXHL4UpogfJ14G4wk16EQogF+v8hmA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.14.1':
+    resolution: {integrity: sha512-im7HE4VBL+aDswvcmfx88Mp1soqL9OBsdDBU8NqDEYtkri0qV0THhQsvZtZeNNlLeCUQ16PZyv7cqutjDF35qw==}
+    cpu: [ppc64le]
+    os: [linux]
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.22.4':
+    resolution: {integrity: sha512-3aVCK9xfWW1oGQpTsYJJPF6bfpWfhbRnhdlyhak2ZiyFLDaayz0EP5j9V1RVLAAxlmWKTDfS9wyRyY3hvhPoOg==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.14.1':
+    resolution: {integrity: sha512-RWdiHuAxWmzPJgaHJdpvUUlDz8sdQz4P2uv367T2JocdDa98iRw2UjIJ4QxSyt077mXZT2X6pKfT2iYtVEvOFw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.22.4':
+    resolution: {integrity: sha512-ePYIir6VYnhgv2C5Xe9u+ico4t8sZWXschR6fMgoPUK31yQu7hTEJb7bCqivHECwIClJfKgE7zYsh1qTP3WHUA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.14.1':
+    resolution: {integrity: sha512-VMgaGQ5zRX6ZqV/fas65/sUGc9cPmsntq2FiGmayW9KMNfWVG/j0BAqImvU4KTeOOgYSf1F+k6at1UfNONuNjA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.22.4':
+    resolution: {integrity: sha512-GqFJ9wLlbB9daxhVlrTe61vJtEY99/xB3C8e4ULVsVfflcpmR6c8UZXjtkMA6FhNONhj2eA5Tk9uAVw5orEs4Q==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.14.1':
+    resolution: {integrity: sha512-9Q7DGjZN+hTdJomaQ3Iub4m6VPu1r94bmK2z3UeWP3dGUecRC54tmVu9vKHTm1bOt3ASoYtEz6JSRLFzrysKlA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.22.4':
+    resolution: {integrity: sha512-87v0ol2sH9GE3cLQLNEy0K/R0pz1nvg76o8M5nhMR0+Q+BBGLnb35P0fVz4CQxHYXaAOhE8HhlkaZfsdUOlHwg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.14.1':
+    resolution: {integrity: sha512-JNEG/Ti55413SsreTguSx0LOVKX902OfXIKVg+TCXO6Gjans/k9O6ww9q3oLGjNDaTLxM+IHFMeXy/0RXL5R/g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.22.4':
+    resolution: {integrity: sha512-UV6FZMUgePDZrFjrNGIWzDo/vABebuXBhJEqrHxrGiU6HikPy0Z3LfdtciIttEUQfuDdCn8fqh7wiFJjCNwO+g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-win32-arm64-msvc@4.14.1':
+    resolution: {integrity: sha512-ryS22I9y0mumlLNwDFYZRDFLwWh3aKaC72CWjFcFvxK0U6v/mOkM5Up1bTbCRAhv3kEIwW2ajROegCIQViUCeA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-arm64-msvc@4.22.4':
+    resolution: {integrity: sha512-BjI+NVVEGAXjGWYHz/vv0pBqfGoUH0IGZ0cICTn7kB9PyjrATSkX+8WkguNjWoj2qSr1im/+tTGRaY+4/PdcQw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.14.1':
+    resolution: {integrity: sha512-TdloItiGk+T0mTxKx7Hp279xy30LspMso+GzQvV2maYePMAWdmrzqSNZhUpPj3CGw12aGj57I026PgLCTu8CGg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.22.4':
+    resolution: {integrity: sha512-SiWG/1TuUdPvYmzmYnmd3IEifzR61Tragkbx9D3+R8mzQqDBz8v+BvZNDlkiTtI9T15KYZhP0ehn3Dld4n9J5g==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.14.1':
+    resolution: {integrity: sha512-wQGI+LY/Py20zdUPq+XCem7JcPOyzIJBm3dli+56DJsQOHbnXZFEwgmnC6el1TPAfC8lBT3m+z69RmLykNUbew==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.22.4':
+    resolution: {integrity: sha512-j8pPKp53/lq9lMXN57S8cFz0MynJk8OWNuUnXct/9KCpKU7DgU3bYMJhwWmcqC0UU29p8Lr0/7KEVcaM6bf47Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.5':
+    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+
+  '@types/node@12.20.55':
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@20.16.6':
+    resolution: {integrity: sha512-T7PpxM/6yeDE+AdlVysT62BX6/bECZOmQAgiFg5NoBd5MQheZ3tzal7f1wvzfiEcmrcJNRi2zRr2nY2zF+0uqw==}
+
+  '@types/semver@7.5.6':
+    resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
+
+  '@vitest/expect@2.1.1':
+    resolution: {integrity: sha512-YeueunS0HiHiQxk+KEOnq/QMzlUuOzbU1Go+PgAsHvvv3tUkJPm9xWt+6ITNTlzsMXUjmgm5T+U7KBPK2qQV6w==}
+
+  '@vitest/mocker@2.1.1':
+    resolution: {integrity: sha512-LNN5VwOEdJqCmJ/2XJBywB11DLlkbY0ooDJW3uRX5cZyYCrc4PI/ePX0iQhE3BiEGiQmK4GE7Q/PqCkkaiPnrA==}
+    peerDependencies:
+      '@vitest/spy': 2.1.1
+      msw: ^2.3.5
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.1':
+    resolution: {integrity: sha512-SjxPFOtuINDUW8/UkElJYQSFtnWX7tMksSGW0vfjxMneFqxVr8YJ979QpMbDW7g+BIiq88RAGDjf7en6rvLPPQ==}
+
+  '@vitest/runner@2.1.1':
+    resolution: {integrity: sha512-uTPuY6PWOYitIkLPidaY5L3t0JJITdGTSwBtwMjKzo5O6RCOEncz9PUN+0pDidX8kTHYjO0EwUIvhlGpnGpxmA==}
+
+  '@vitest/snapshot@2.1.1':
+    resolution: {integrity: sha512-BnSku1WFy7r4mm96ha2FzN99AZJgpZOWrAhtQfoxjUU5YMRpq1zmHRq7a5K9/NjqonebO7iVDla+VvZS8BOWMw==}
+
+  '@vitest/spy@2.1.1':
+    resolution: {integrity: sha512-ZM39BnZ9t/xZ/nF4UwRH5il0Sw93QnZXd9NAZGRpIgj0yvVwPpLd702s/Cx955rGaMlyBQkZJ2Ir7qyY48VZ+g==}
+
+  '@vitest/utils@2.1.1':
+    resolution: {integrity: sha512-Y6Q9TsI+qJ2CC0ZKj6VBb+T8UPz593N113nnUykqwANqhgf3QkZeHFlusgKLTqrnVHbj/XDKZcDHol+dxVT+rQ==}
+
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.0.1:
+    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  better-path-resolve@1.0.0:
+    resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
+    engines: {node: '>=4'}
+
+  binary-extensions@2.2.0:
+    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
+    engines: {node: '>=8'}
+
+  brace-expansion@2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  braces@3.0.2:
+    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+    engines: {node: '>=8'}
+
+  bundle-require@5.0.0:
+    resolution: {integrity: sha512-GuziW3fSSmopcx4KRymQEJVbZUfqlCqcq7dvs6TYwKRZiegK/2buMxQTPs6MGlNv50wms1699qYO54R8XfRX4w==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.1.1:
+    resolution: {integrity: sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==}
+    engines: {node: '>=12'}
+
+  chardet@0.7.0:
+    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  consola@3.2.3:
+    resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  cross-spawn@5.1.0:
+    resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
+
+  cross-spawn@7.0.3:
+    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+    engines: {node: '>= 8'}
+
+  dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
+  debug@4.3.7:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  detect-indent@6.1.0:
+    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
+
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+
+  dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  enquirer@2.4.1:
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
+    engines: {node: '>=8.6'}
+
+  esbuild@0.20.2:
+    resolution: {integrity: sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.23.1:
+    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
+  extendable-error@0.1.7:
+    resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
+
+  external-editor@3.1.0:
+    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
+    engines: {node: '>=4'}
+
+  fast-glob@3.3.2:
+    resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
+    engines: {node: '>=8.6.0'}
+
+  fastq@1.16.0:
+    resolution: {integrity: sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==}
+
+  fdir@6.3.0:
+    resolution: {integrity: sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fill-range@7.0.1:
+    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+    engines: {node: '>=8'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
+  foreground-child@3.1.1:
+    resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
+    engines: {node: '>=14'}
+
+  fs-extra@7.0.1:
+    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
+    engines: {node: '>=6 <7 || >=8'}
+
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob@10.3.10:
+    resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  human-id@1.0.2:
+    resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  ignore@5.3.0:
+    resolution: {integrity: sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==}
+    engines: {node: '>= 4'}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  is-subdir@1.2.0:
+    resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
+    engines: {node: '>=4'}
+
+  is-windows@1.0.2:
+    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
+    engines: {node: '>=0.10.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@2.3.6:
+    resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
+    engines: {node: '>=14'}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  js-yaml@3.14.1:
+    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
+
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  lilconfig@3.1.2:
+    resolution: {integrity: sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
+  lodash.sortby@4.7.0:
+    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
+
+  lodash.startcase@4.4.0:
+    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
+  loupe@3.1.1:
+    resolution: {integrity: sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==}
+
+  lru-cache@10.1.0:
+    resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
+    engines: {node: 14 || >=16.14}
+
+  lru-cache@4.1.5:
+    resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
+  magic-string@0.30.11:
+    resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.5:
+    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
+    engines: {node: '>=8.6'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.0.4:
+    resolution: {integrity: sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.7:
+    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
+  os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
+
+  outdent@0.5.0:
+    resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
+  p-filter@2.1.0:
+    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
+    engines: {node: '>=8'}
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-map@2.1.0:
+    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
+    engines: {node: '>=6'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
+  package-manager-detector@0.2.0:
+    resolution: {integrity: sha512-E385OSk9qDcXhcM9LNSe4sdhx8a9mAPrZ4sMLW+tmxl5ZuGtPUcdFu+MPP2jbgiWAZ6Pfe5soGFMd+0Db5Vrog==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.10.1:
+    resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.0:
+    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.0:
+    resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
+
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
+  pify@4.0.1:
+    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
+    engines: {node: '>=6'}
+
+  pirates@4.0.6:
+    resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
+    engines: {node: '>= 6'}
+
+  playwright-core@1.47.1:
+    resolution: {integrity: sha512-i1iyJdLftqtt51mEk6AhYFaAJCDx0xQ/O5NU8EKaWFgMjItPVma542Nh/Aq8aLCjIJSzjaiEQGW/nyqLkGF1OQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.47.1:
+    resolution: {integrity: sha512-SUEKi6947IqYbKxRiqnbUobVZY4bF1uu+ZnZNJX9DfU1tlf2UhWfvVjLf01pQx9URsOr18bFVUKXmanYWhbfkw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss@8.4.38:
+    resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
+  pseudomap@1.0.2:
+    resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  read-yaml-file@1.1.0:
+    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
+    engines: {node: '>=6'}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
+  regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  reusify@1.0.4:
+    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rollup@4.14.1:
+    resolution: {integrity: sha512-4LnHSdd3QK2pa1J6dFbfm1HN0D7vSK/ZuZTsdyUAlA6Rr1yTouUTL13HaDOGJVgby461AhrNGBS7sCGXXtT+SA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rollup@4.22.4:
+    resolution: {integrity: sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@1.2.0:
+    resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
+    engines: {node: '>=0.10.0'}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@1.0.0:
+    resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
+    engines: {node: '>=0.10.0'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
+  source-map-js@1.2.0:
+    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.8.0-beta.0:
+    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
+    engines: {node: '>= 8'}
+
+  spawndamnit@2.0.0:
+    resolution: {integrity: sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.7.0:
+    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
+  sucrase@3.35.0:
+    resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  term-size@2.2.1:
+    resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
+    engines: {node: '>=8'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.0:
+    resolution: {integrity: sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==}
+
+  tinyglobby@0.2.6:
+    resolution: {integrity: sha512-NbBoFBpqfcgd1tCiO8Lkfdk+xrA7mlLR9zgvZcZWQQwU63XAfUePyd6wZBaU93Hqw347lHnwFzttAkemHzzz4g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.0.1:
+    resolution: {integrity: sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  tmp@0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@1.0.1:
+    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.3.0:
+    resolution: {integrity: sha512-ALscEeyS03IomcuNdFdc0YWGVIkwH1Ws7nfTbAPuoILvEV2hpGQAY72LIOjglGo4ShWpZfpBqP/jpQVCzqYQag==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  typescript@5.6.2:
+    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
+
+  vite-node@2.1.1:
+    resolution: {integrity: sha512-N/mGckI1suG/5wQI35XeR9rsMsPqKXzq1CdUndzVstBj/HvyxxGctwnK6WX43NGt5L3Z5tcRf83g4TITKJhPrA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.2.8:
+    resolution: {integrity: sha512-OyZR+c1CE8yeHw5V5t59aXsUPPVTHMDjEZz8MgguLL/Q7NblxhZUlTu9xSPqlsUO/y+X7dlU05jdhvyycD55DA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.1:
+    resolution: {integrity: sha512-97We7/VC0e9X5zBVkvt7SGQMGrRtn3KtySFQG5fpaMlS+l62eeXRQO633AYhSTC3z7IMebnPPNjGXVGNRFlxBA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.1
+      '@vitest/ui': 2.1.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@4.0.2:
+    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  whatwg-url@7.1.0:
+    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
+
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  yallist@2.1.2:
+    resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+snapshots:
+
+  '@babel/runtime@7.23.8':
+    dependencies:
+      regenerator-runtime: 0.14.1
+
+  '@biomejs/biome@1.9.2':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 1.9.2
       '@biomejs/cli-darwin-x64': 1.9.2
@@ -55,82 +1533,32 @@ packages:
       '@biomejs/cli-linux-x64-musl': 1.9.2
       '@biomejs/cli-win32-arm64': 1.9.2
       '@biomejs/cli-win32-x64': 1.9.2
-    dev: true
 
-  /@biomejs/cli-darwin-arm64@1.9.2:
-    resolution: {integrity: sha512-rbs9uJHFmhqB3Td0Ro+1wmeZOHhAPTL3WHr8NtaVczUmDhXkRDWScaxicG9+vhSLj1iLrW47itiK6xiIJy6vaA==}
-    engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
+  '@biomejs/cli-darwin-arm64@1.9.2':
     optional: true
 
-  /@biomejs/cli-darwin-x64@1.9.2:
-    resolution: {integrity: sha512-BlfULKijNaMigQ9GH9fqJVt+3JTDOSiZeWOQtG/1S1sa8Lp046JHG3wRJVOvekTPL9q/CNFW1NVG8J0JN+L1OA==}
-    engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
+  '@biomejs/cli-darwin-x64@1.9.2':
     optional: true
 
-  /@biomejs/cli-linux-arm64-musl@1.9.2:
-    resolution: {integrity: sha512-ZATvbUWhNxegSALUnCKWqetTZqrK72r2RsFD19OK5jXDj/7o1hzI1KzDNG78LloZxftrwr3uI9SqCLh06shSZw==}
-    engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@biomejs/cli-linux-arm64-musl@1.9.2':
     optional: true
 
-  /@biomejs/cli-linux-arm64@1.9.2:
-    resolution: {integrity: sha512-T8TJuSxuBDeQCQzxZu2o3OU4eyLumTofhCxxFd3+aH2AEWVMnH7Z/c3QP1lHI5RRMBP9xIJeMORqDQ5j+gVZzw==}
-    engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@biomejs/cli-linux-arm64@1.9.2':
     optional: true
 
-  /@biomejs/cli-linux-x64-musl@1.9.2:
-    resolution: {integrity: sha512-CjPM6jT1miV5pry9C7qv8YJk0FIZvZd86QRD3atvDgfgeh9WQU0k2Aoo0xUcPdTnoz0WNwRtDicHxwik63MmSg==}
-    engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@biomejs/cli-linux-x64-musl@1.9.2':
     optional: true
 
-  /@biomejs/cli-linux-x64@1.9.2:
-    resolution: {integrity: sha512-T0cPk3C3Jr2pVlsuQVTBqk2qPjTm8cYcTD9p/wmR9MeVqui1C/xTVfOIwd3miRODFMrJaVQ8MYSXnVIhV9jTjg==}
-    engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@biomejs/cli-linux-x64@1.9.2':
     optional: true
 
-  /@biomejs/cli-win32-arm64@1.9.2:
-    resolution: {integrity: sha512-2x7gSty75bNIeD23ZRPXyox6Z/V0M71ObeJtvQBhi1fgrvPdtkEuw7/0wEHg6buNCubzOFuN9WYJm6FKoUHfhg==}
-    engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
+  '@biomejs/cli-win32-arm64@1.9.2':
     optional: true
 
-  /@biomejs/cli-win32-x64@1.9.2:
-    resolution: {integrity: sha512-JC3XvdYcjmu1FmAehVwVV0SebLpeNTnO2ZaMdGCSOdS7f8O9Fq14T2P1gTG1Q29Q8Dt1S03hh0IdVpIZykOL8g==}
-    engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
+  '@biomejs/cli-win32-x64@1.9.2':
     optional: true
 
-  /@changesets/apply-release-plan@7.0.5:
-    resolution: {integrity: sha512-1cWCk+ZshEkSVEZrm2fSj1Gz8sYvxgUL4Q78+1ZZqeqfuevPTPk033/yUZ3df8BKMohkqqHfzj0HOOrG0KtXTw==}
+  '@changesets/apply-release-plan@7.0.5':
     dependencies:
       '@changesets/config': 3.0.3
       '@changesets/get-version-range-type': 0.4.0
@@ -145,10 +1573,8 @@ packages:
       prettier: 2.8.8
       resolve-from: 5.0.0
       semver: 7.5.4
-    dev: true
 
-  /@changesets/assemble-release-plan@6.0.4:
-    resolution: {integrity: sha512-nqICnvmrwWj4w2x0fOhVj2QEGdlUuwVAwESrUo5HLzWMI1rE5SWfsr9ln+rDqWB6RQ2ZyaMZHUcU7/IRaUJS+Q==}
+  '@changesets/assemble-release-plan@6.0.4':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.2
@@ -156,27 +1582,20 @@ packages:
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
       semver: 7.5.4
-    dev: true
 
-  /@changesets/changelog-git@0.2.0:
-    resolution: {integrity: sha512-bHOx97iFI4OClIT35Lok3sJAwM31VbUM++gnMBV16fdbtBhgYu4dxsphBF/0AZZsyAHMrnM0yFcj5gZM1py6uQ==}
+  '@changesets/changelog-git@0.2.0':
     dependencies:
       '@changesets/types': 6.0.0
-    dev: true
 
-  /@changesets/changelog-github@0.5.0:
-    resolution: {integrity: sha512-zoeq2LJJVcPJcIotHRJEEA2qCqX0AQIeFE+L21L8sRLPVqDhSXY8ZWAt2sohtBpFZkBwu+LUwMSKRr2lMy3LJA==}
+  '@changesets/changelog-github@0.5.0':
     dependencies:
       '@changesets/get-github-info': 0.6.0
       '@changesets/types': 6.0.0
       dotenv: 8.6.0
     transitivePeerDependencies:
       - encoding
-    dev: true
 
-  /@changesets/cli@2.27.8:
-    resolution: {integrity: sha512-gZNyh+LdSsI82wBSHLQ3QN5J30P4uHKJ4fXgoGwQxfXwYFTJzDdvIJasZn8rYQtmKhyQuiBj4SSnLuKlxKWq4w==}
-    hasBin: true
+  '@changesets/cli@2.27.8':
     dependencies:
       '@changesets/apply-release-plan': 7.0.5
       '@changesets/assemble-release-plan': 6.0.4
@@ -208,10 +1627,8 @@ packages:
       semver: 7.5.4
       spawndamnit: 2.0.0
       term-size: 2.2.1
-    dev: true
 
-  /@changesets/config@3.0.3:
-    resolution: {integrity: sha512-vqgQZMyIcuIpw9nqFIpTSNyc/wgm/Lu1zKN5vECy74u95Qx/Wa9g27HdgO4NkVAaq+BGA8wUc/qvbvVNs93n6A==}
+  '@changesets/config@3.0.3':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.2
@@ -220,34 +1637,26 @@ packages:
       '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
       micromatch: 4.0.5
-    dev: true
 
-  /@changesets/errors@0.2.0:
-    resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
+  '@changesets/errors@0.2.0':
     dependencies:
       extendable-error: 0.1.7
-    dev: true
 
-  /@changesets/get-dependents-graph@2.1.2:
-    resolution: {integrity: sha512-sgcHRkiBY9i4zWYBwlVyAjEM9sAzs4wYVwJUdnbDLnVG3QwAaia1Mk5P8M7kraTOZN+vBET7n8KyB0YXCbFRLQ==}
+  '@changesets/get-dependents-graph@2.1.2':
     dependencies:
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.0
       semver: 7.5.4
-    dev: true
 
-  /@changesets/get-github-info@0.6.0:
-    resolution: {integrity: sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==}
+  '@changesets/get-github-info@0.6.0':
     dependencies:
       dataloader: 1.4.0
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
-    dev: true
 
-  /@changesets/get-release-plan@4.0.4:
-    resolution: {integrity: sha512-SicG/S67JmPTrdcc9Vpu0wSQt7IiuN0dc8iR5VScnnTVPfIaLvKmEGRvIaF0kcn8u5ZqLbormZNTO77bCEvyWw==}
+  '@changesets/get-release-plan@4.0.4':
     dependencies:
       '@changesets/assemble-release-plan': 6.0.4
       '@changesets/config': 3.0.3
@@ -255,46 +1664,34 @@ packages:
       '@changesets/read': 0.6.1
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-    dev: true
 
-  /@changesets/get-version-range-type@0.4.0:
-    resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
-    dev: true
+  '@changesets/get-version-range-type@0.4.0': {}
 
-  /@changesets/git@3.0.1:
-    resolution: {integrity: sha512-pdgHcYBLCPcLd82aRcuO0kxCDbw/yISlOtkmwmE8Odo1L6hSiZrBOsRl84eYG7DRCab/iHnOkWqExqc4wxk2LQ==}
+  '@changesets/git@3.0.1':
     dependencies:
       '@changesets/errors': 0.2.0
       '@manypkg/get-packages': 1.1.3
       is-subdir: 1.2.0
       micromatch: 4.0.5
       spawndamnit: 2.0.0
-    dev: true
 
-  /@changesets/logger@0.1.1:
-    resolution: {integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==}
+  '@changesets/logger@0.1.1':
     dependencies:
       picocolors: 1.1.0
-    dev: true
 
-  /@changesets/parse@0.4.0:
-    resolution: {integrity: sha512-TS/9KG2CdGXS27S+QxbZXgr8uPsP4yNJYb4BC2/NeFUj80Rni3TeD2qwWmabymxmrLo7JEsytXH1FbpKTbvivw==}
+  '@changesets/parse@0.4.0':
     dependencies:
       '@changesets/types': 6.0.0
       js-yaml: 3.14.1
-    dev: true
 
-  /@changesets/pre@2.0.1:
-    resolution: {integrity: sha512-vvBJ/If4jKM4tPz9JdY2kGOgWmCowUYOi5Ycv8dyLnEE8FgpYYUo1mgJZxcdtGGP3aG8rAQulGLyyXGSLkIMTQ==}
+  '@changesets/pre@2.0.1':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
-    dev: true
 
-  /@changesets/read@0.6.1:
-    resolution: {integrity: sha512-jYMbyXQk3nwP25nRzQQGa1nKLY0KfoOV7VLgwucI0bUO8t8ZLCr6LZmgjXsiKuRDc+5A6doKPr9w2d+FEJ55zQ==}
+  '@changesets/read@0.6.1':
     dependencies:
       '@changesets/git': 3.0.1
       '@changesets/logger': 0.1.1
@@ -303,512 +1700,200 @@ packages:
       fs-extra: 7.0.1
       p-filter: 2.1.0
       picocolors: 1.1.0
-    dev: true
 
-  /@changesets/should-skip-package@0.1.1:
-    resolution: {integrity: sha512-H9LjLbF6mMHLtJIc/eHR9Na+MifJ3VxtgP/Y+XLn4BF7tDTEN1HNYtH6QMcjP1uxp9sjaFYmW8xqloaCi/ckTg==}
+  '@changesets/should-skip-package@0.1.1':
     dependencies:
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-    dev: true
 
-  /@changesets/types@4.1.0:
-    resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
-    dev: true
+  '@changesets/types@4.1.0': {}
 
-  /@changesets/types@6.0.0:
-    resolution: {integrity: sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==}
-    dev: true
+  '@changesets/types@6.0.0': {}
 
-  /@changesets/write@0.3.2:
-    resolution: {integrity: sha512-kDxDrPNpUgsjDbWBvUo27PzKX4gqeKOlhibaOXDJA6kuBisGqNHv/HwGJrAu8U/dSf8ZEFIeHIPtvSlZI1kULw==}
+  '@changesets/write@0.3.2':
     dependencies:
       '@changesets/types': 6.0.0
       fs-extra: 7.0.1
       human-id: 1.0.2
       prettier: 2.8.8
-    dev: true
 
-  /@esbuild/aix-ppc64@0.20.2:
-    resolution: {integrity: sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
-    requiresBuild: true
-    dev: true
+  '@esbuild/aix-ppc64@0.20.2':
     optional: true
 
-  /@esbuild/aix-ppc64@0.23.1:
-    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-    requiresBuild: true
-    dev: true
+  '@esbuild/aix-ppc64@0.23.1':
     optional: true
 
-  /@esbuild/android-arm64@0.20.2:
-    resolution: {integrity: sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
+  '@esbuild/android-arm64@0.20.2':
     optional: true
 
-  /@esbuild/android-arm64@0.23.1:
-    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
+  '@esbuild/android-arm64@0.23.1':
     optional: true
 
-  /@esbuild/android-arm@0.20.2:
-    resolution: {integrity: sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
+  '@esbuild/android-arm@0.20.2':
     optional: true
 
-  /@esbuild/android-arm@0.23.1:
-    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
+  '@esbuild/android-arm@0.23.1':
     optional: true
 
-  /@esbuild/android-x64@0.20.2:
-    resolution: {integrity: sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
+  '@esbuild/android-x64@0.20.2':
     optional: true
 
-  /@esbuild/android-x64@0.23.1:
-    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
+  '@esbuild/android-x64@0.23.1':
     optional: true
 
-  /@esbuild/darwin-arm64@0.20.2:
-    resolution: {integrity: sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
+  '@esbuild/darwin-arm64@0.20.2':
     optional: true
 
-  /@esbuild/darwin-arm64@0.23.1:
-    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
+  '@esbuild/darwin-arm64@0.23.1':
     optional: true
 
-  /@esbuild/darwin-x64@0.20.2:
-    resolution: {integrity: sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
+  '@esbuild/darwin-x64@0.20.2':
     optional: true
 
-  /@esbuild/darwin-x64@0.23.1:
-    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
+  '@esbuild/darwin-x64@0.23.1':
     optional: true
 
-  /@esbuild/freebsd-arm64@0.20.2:
-    resolution: {integrity: sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
+  '@esbuild/freebsd-arm64@0.20.2':
     optional: true
 
-  /@esbuild/freebsd-arm64@0.23.1:
-    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
+  '@esbuild/freebsd-arm64@0.23.1':
     optional: true
 
-  /@esbuild/freebsd-x64@0.20.2:
-    resolution: {integrity: sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
+  '@esbuild/freebsd-x64@0.20.2':
     optional: true
 
-  /@esbuild/freebsd-x64@0.23.1:
-    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
+  '@esbuild/freebsd-x64@0.23.1':
     optional: true
 
-  /@esbuild/linux-arm64@0.20.2:
-    resolution: {integrity: sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-arm64@0.20.2':
     optional: true
 
-  /@esbuild/linux-arm64@0.23.1:
-    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-arm64@0.23.1':
     optional: true
 
-  /@esbuild/linux-arm@0.20.2:
-    resolution: {integrity: sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-arm@0.20.2':
     optional: true
 
-  /@esbuild/linux-arm@0.23.1:
-    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-arm@0.23.1':
     optional: true
 
-  /@esbuild/linux-ia32@0.20.2:
-    resolution: {integrity: sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-ia32@0.20.2':
     optional: true
 
-  /@esbuild/linux-ia32@0.23.1:
-    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-ia32@0.23.1':
     optional: true
 
-  /@esbuild/linux-loong64@0.20.2:
-    resolution: {integrity: sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-loong64@0.20.2':
     optional: true
 
-  /@esbuild/linux-loong64@0.23.1:
-    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-loong64@0.23.1':
     optional: true
 
-  /@esbuild/linux-mips64el@0.20.2:
-    resolution: {integrity: sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-mips64el@0.20.2':
     optional: true
 
-  /@esbuild/linux-mips64el@0.23.1:
-    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-mips64el@0.23.1':
     optional: true
 
-  /@esbuild/linux-ppc64@0.20.2:
-    resolution: {integrity: sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-ppc64@0.20.2':
     optional: true
 
-  /@esbuild/linux-ppc64@0.23.1:
-    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-ppc64@0.23.1':
     optional: true
 
-  /@esbuild/linux-riscv64@0.20.2:
-    resolution: {integrity: sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-riscv64@0.20.2':
     optional: true
 
-  /@esbuild/linux-riscv64@0.23.1:
-    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-riscv64@0.23.1':
     optional: true
 
-  /@esbuild/linux-s390x@0.20.2:
-    resolution: {integrity: sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-s390x@0.20.2':
     optional: true
 
-  /@esbuild/linux-s390x@0.23.1:
-    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-s390x@0.23.1':
     optional: true
 
-  /@esbuild/linux-x64@0.20.2:
-    resolution: {integrity: sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-x64@0.20.2':
     optional: true
 
-  /@esbuild/linux-x64@0.23.1:
-    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@esbuild/linux-x64@0.23.1':
     optional: true
 
-  /@esbuild/netbsd-x64@0.20.2:
-    resolution: {integrity: sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
+  '@esbuild/netbsd-x64@0.20.2':
     optional: true
 
-  /@esbuild/netbsd-x64@0.23.1:
-    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
+  '@esbuild/netbsd-x64@0.23.1':
     optional: true
 
-  /@esbuild/openbsd-arm64@0.23.1:
-    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
+  '@esbuild/openbsd-arm64@0.23.1':
     optional: true
 
-  /@esbuild/openbsd-x64@0.20.2:
-    resolution: {integrity: sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
+  '@esbuild/openbsd-x64@0.20.2':
     optional: true
 
-  /@esbuild/openbsd-x64@0.23.1:
-    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
+  '@esbuild/openbsd-x64@0.23.1':
     optional: true
 
-  /@esbuild/sunos-x64@0.20.2:
-    resolution: {integrity: sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
+  '@esbuild/sunos-x64@0.20.2':
     optional: true
 
-  /@esbuild/sunos-x64@0.23.1:
-    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
+  '@esbuild/sunos-x64@0.23.1':
     optional: true
 
-  /@esbuild/win32-arm64@0.20.2:
-    resolution: {integrity: sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
+  '@esbuild/win32-arm64@0.20.2':
     optional: true
 
-  /@esbuild/win32-arm64@0.23.1:
-    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
+  '@esbuild/win32-arm64@0.23.1':
     optional: true
 
-  /@esbuild/win32-ia32@0.20.2:
-    resolution: {integrity: sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
+  '@esbuild/win32-ia32@0.20.2':
     optional: true
 
-  /@esbuild/win32-ia32@0.23.1:
-    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
+  '@esbuild/win32-ia32@0.23.1':
     optional: true
 
-  /@esbuild/win32-x64@0.20.2:
-    resolution: {integrity: sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
+  '@esbuild/win32-x64@0.20.2':
     optional: true
 
-  /@esbuild/win32-x64@0.23.1:
-    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
+  '@esbuild/win32-x64@0.23.1':
     optional: true
 
-  /@isaacs/cliui@8.0.2:
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
+  '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
-      string-width-cjs: /string-width@4.2.3
+      string-width-cjs: string-width@4.2.3
       strip-ansi: 7.1.0
-      strip-ansi-cjs: /strip-ansi@6.0.1
+      strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
-      wrap-ansi-cjs: /wrap-ansi@7.0.0
-    dev: true
+      wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  /@jridgewell/gen-mapping@0.3.3:
-    resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
-    engines: {node: '>=6.0.0'}
+  '@jridgewell/gen-mapping@0.3.3':
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.20
-    dev: true
 
-  /@jridgewell/resolve-uri@3.1.1:
-    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
-    engines: {node: '>=6.0.0'}
-    dev: true
+  '@jridgewell/resolve-uri@3.1.1': {}
 
-  /@jridgewell/set-array@1.1.2:
-    resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
-    engines: {node: '>=6.0.0'}
-    dev: true
+  '@jridgewell/set-array@1.1.2': {}
 
-  /@jridgewell/sourcemap-codec@1.4.15:
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-    dev: true
+  '@jridgewell/sourcemap-codec@1.4.15': {}
 
-  /@jridgewell/sourcemap-codec@1.5.0:
-    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
-    dev: true
+  '@jridgewell/sourcemap-codec@1.5.0': {}
 
-  /@jridgewell/trace-mapping@0.3.20:
-    resolution: {integrity: sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==}
+  '@jridgewell/trace-mapping@0.3.20':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
-  /@manypkg/find-root@1.1.0:
-    resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
+  '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.23.8
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
-    dev: true
 
-  /@manypkg/get-packages@1.1.3:
-    resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+  '@manypkg/get-packages@1.1.3':
     dependencies:
       '@babel/runtime': 7.23.8
       '@changesets/types': 4.1.0
@@ -816,494 +1901,231 @@ packages:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
-    dev: true
 
-  /@nodelib/fs.scandir@2.1.5:
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
+  '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
-    dev: true
 
-  /@nodelib/fs.stat@2.0.5:
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
-    dev: true
+  '@nodelib/fs.stat@2.0.5': {}
 
-  /@nodelib/fs.walk@1.2.8:
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
+  '@nodelib/fs.walk@1.2.8':
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.16.0
-    dev: true
 
-  /@pkgjs/parseargs@0.11.0:
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
-    requiresBuild: true
-    dev: true
+  '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  /@playwright/test@1.47.1:
-    resolution: {integrity: sha512-dbWpcNQZ5nj16m+A5UNScYx7HX5trIy7g4phrcitn+Nk83S32EBX/CLU4hiF4RGKX/yRc93AAqtfaXB7JWBd4Q==}
-    engines: {node: '>=18'}
-    hasBin: true
+  '@playwright/test@1.47.1':
     dependencies:
       playwright: 1.47.1
-    dev: false
 
-  /@rollup/rollup-android-arm-eabi@4.14.1:
-    resolution: {integrity: sha512-fH8/o8nSUek8ceQnT7K4EQbSiV7jgkHq81m9lWZFIXjJ7lJzpWXbQFpT/Zh6OZYnpFykvzC3fbEvEAFZu03dPA==}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-android-arm-eabi@4.14.1':
     optional: true
 
-  /@rollup/rollup-android-arm-eabi@4.22.4:
-    resolution: {integrity: sha512-Fxamp4aEZnfPOcGA8KSNEohV8hX7zVHOemC8jVBoBUHu5zpJK/Eu3uJwt6BMgy9fkvzxDaurgj96F/NiLukF2w==}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-android-arm-eabi@4.22.4':
     optional: true
 
-  /@rollup/rollup-android-arm64@4.14.1:
-    resolution: {integrity: sha512-Y/9OHLjzkunF+KGEoJr3heiD5X9OLa8sbT1lm0NYeKyaM3oMhhQFvPB0bNZYJwlq93j8Z6wSxh9+cyKQaxS7PQ==}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-android-arm64@4.14.1':
     optional: true
 
-  /@rollup/rollup-android-arm64@4.22.4:
-    resolution: {integrity: sha512-VXoK5UMrgECLYaMuGuVTOx5kcuap1Jm8g/M83RnCHBKOqvPPmROFJGQaZhGccnsFtfXQ3XYa4/jMCJvZnbJBdA==}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-android-arm64@4.22.4':
     optional: true
 
-  /@rollup/rollup-darwin-arm64@4.14.1:
-    resolution: {integrity: sha512-+kecg3FY84WadgcuSVm6llrABOdQAEbNdnpi5X3UwWiFVhZIZvKgGrF7kmLguvxHNQy+UuRV66cLVl3S+Rkt+Q==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-darwin-arm64@4.14.1':
     optional: true
 
-  /@rollup/rollup-darwin-arm64@4.22.4:
-    resolution: {integrity: sha512-xMM9ORBqu81jyMKCDP+SZDhnX2QEVQzTcC6G18KlTQEzWK8r/oNZtKuZaCcHhnsa6fEeOBionoyl5JsAbE/36Q==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-darwin-arm64@4.22.4':
     optional: true
 
-  /@rollup/rollup-darwin-x64@4.14.1:
-    resolution: {integrity: sha512-2pYRzEjVqq2TB/UNv47BV/8vQiXkFGVmPFwJb+1E0IFFZbIX8/jo1olxqqMbo6xCXf8kabANhp5bzCij2tFLUA==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-darwin-x64@4.14.1':
     optional: true
 
-  /@rollup/rollup-darwin-x64@4.22.4:
-    resolution: {integrity: sha512-aJJyYKQwbHuhTUrjWjxEvGnNNBCnmpHDvrb8JFDbeSH3m2XdHcxDd3jthAzvmoI8w/kSjd2y0udT+4okADsZIw==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-darwin-x64@4.22.4':
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.14.1:
-    resolution: {integrity: sha512-mS6wQ6Do6/wmrF9aTFVpIJ3/IDXhg1EZcQFYHZLHqw6AzMBjTHWnCG35HxSqUNphh0EHqSM6wRTT8HsL1C0x5g==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-linux-arm-gnueabihf@4.14.1':
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.22.4:
-    resolution: {integrity: sha512-j63YtCIRAzbO+gC2L9dWXRh5BFetsv0j0va0Wi9epXDgU/XUi5dJKo4USTttVyK7fGw2nPWK0PbAvyliz50SCQ==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-linux-arm-gnueabihf@4.22.4':
     optional: true
 
-  /@rollup/rollup-linux-arm-musleabihf@4.22.4:
-    resolution: {integrity: sha512-dJnWUgwWBX1YBRsuKKMOlXCzh2Wu1mlHzv20TpqEsfdZLb3WoJW2kIEsGwLkroYf24IrPAvOT/ZQ2OYMV6vlrg==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-linux-arm-musleabihf@4.22.4':
     optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.14.1:
-    resolution: {integrity: sha512-p9rGKYkHdFMzhckOTFubfxgyIO1vw//7IIjBBRVzyZebWlzRLeNhqxuSaZ7kCEKVkm/kuC9fVRW9HkC/zNRG2w==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-linux-arm64-gnu@4.14.1':
     optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.22.4:
-    resolution: {integrity: sha512-AdPRoNi3NKVLolCN/Sp4F4N1d98c4SBnHMKoLuiG6RXgoZ4sllseuGioszumnPGmPM2O7qaAX/IJdeDU8f26Aw==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-linux-arm64-gnu@4.22.4':
     optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.14.1:
-    resolution: {integrity: sha512-nDY6Yz5xS/Y4M2i9JLQd3Rofh5OR8Bn8qe3Mv/qCVpHFlwtZSBYSPaU4mrGazWkXrdQ98GB//H0BirGR/SKFSw==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-linux-arm64-musl@4.14.1':
     optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.22.4:
-    resolution: {integrity: sha512-Gl0AxBtDg8uoAn5CCqQDMqAx22Wx22pjDOjBdmG0VIWX3qUBHzYmOKh8KXHL4UpogfJ14G4wk16EQogF+v8hmA==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-linux-arm64-musl@4.22.4':
     optional: true
 
-  /@rollup/rollup-linux-powerpc64le-gnu@4.14.1:
-    resolution: {integrity: sha512-im7HE4VBL+aDswvcmfx88Mp1soqL9OBsdDBU8NqDEYtkri0qV0THhQsvZtZeNNlLeCUQ16PZyv7cqutjDF35qw==}
-    cpu: [ppc64le]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-linux-powerpc64le-gnu@4.14.1':
     optional: true
 
-  /@rollup/rollup-linux-powerpc64le-gnu@4.22.4:
-    resolution: {integrity: sha512-3aVCK9xfWW1oGQpTsYJJPF6bfpWfhbRnhdlyhak2ZiyFLDaayz0EP5j9V1RVLAAxlmWKTDfS9wyRyY3hvhPoOg==}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-linux-powerpc64le-gnu@4.22.4':
     optional: true
 
-  /@rollup/rollup-linux-riscv64-gnu@4.14.1:
-    resolution: {integrity: sha512-RWdiHuAxWmzPJgaHJdpvUUlDz8sdQz4P2uv367T2JocdDa98iRw2UjIJ4QxSyt077mXZT2X6pKfT2iYtVEvOFw==}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-linux-riscv64-gnu@4.14.1':
     optional: true
 
-  /@rollup/rollup-linux-riscv64-gnu@4.22.4:
-    resolution: {integrity: sha512-ePYIir6VYnhgv2C5Xe9u+ico4t8sZWXschR6fMgoPUK31yQu7hTEJb7bCqivHECwIClJfKgE7zYsh1qTP3WHUA==}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-linux-riscv64-gnu@4.22.4':
     optional: true
 
-  /@rollup/rollup-linux-s390x-gnu@4.14.1:
-    resolution: {integrity: sha512-VMgaGQ5zRX6ZqV/fas65/sUGc9cPmsntq2FiGmayW9KMNfWVG/j0BAqImvU4KTeOOgYSf1F+k6at1UfNONuNjA==}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-linux-s390x-gnu@4.14.1':
     optional: true
 
-  /@rollup/rollup-linux-s390x-gnu@4.22.4:
-    resolution: {integrity: sha512-GqFJ9wLlbB9daxhVlrTe61vJtEY99/xB3C8e4ULVsVfflcpmR6c8UZXjtkMA6FhNONhj2eA5Tk9uAVw5orEs4Q==}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-linux-s390x-gnu@4.22.4':
     optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.14.1:
-    resolution: {integrity: sha512-9Q7DGjZN+hTdJomaQ3Iub4m6VPu1r94bmK2z3UeWP3dGUecRC54tmVu9vKHTm1bOt3ASoYtEz6JSRLFzrysKlA==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-linux-x64-gnu@4.14.1':
     optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.22.4:
-    resolution: {integrity: sha512-87v0ol2sH9GE3cLQLNEy0K/R0pz1nvg76o8M5nhMR0+Q+BBGLnb35P0fVz4CQxHYXaAOhE8HhlkaZfsdUOlHwg==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-linux-x64-gnu@4.22.4':
     optional: true
 
-  /@rollup/rollup-linux-x64-musl@4.14.1:
-    resolution: {integrity: sha512-JNEG/Ti55413SsreTguSx0LOVKX902OfXIKVg+TCXO6Gjans/k9O6ww9q3oLGjNDaTLxM+IHFMeXy/0RXL5R/g==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-linux-x64-musl@4.14.1':
     optional: true
 
-  /@rollup/rollup-linux-x64-musl@4.22.4:
-    resolution: {integrity: sha512-UV6FZMUgePDZrFjrNGIWzDo/vABebuXBhJEqrHxrGiU6HikPy0Z3LfdtciIttEUQfuDdCn8fqh7wiFJjCNwO+g==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-linux-x64-musl@4.22.4':
     optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.14.1:
-    resolution: {integrity: sha512-ryS22I9y0mumlLNwDFYZRDFLwWh3aKaC72CWjFcFvxK0U6v/mOkM5Up1bTbCRAhv3kEIwW2ajROegCIQViUCeA==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-win32-arm64-msvc@4.14.1':
     optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.22.4:
-    resolution: {integrity: sha512-BjI+NVVEGAXjGWYHz/vv0pBqfGoUH0IGZ0cICTn7kB9PyjrATSkX+8WkguNjWoj2qSr1im/+tTGRaY+4/PdcQw==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-win32-arm64-msvc@4.22.4':
     optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.14.1:
-    resolution: {integrity: sha512-TdloItiGk+T0mTxKx7Hp279xy30LspMso+GzQvV2maYePMAWdmrzqSNZhUpPj3CGw12aGj57I026PgLCTu8CGg==}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-win32-ia32-msvc@4.14.1':
     optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.22.4:
-    resolution: {integrity: sha512-SiWG/1TuUdPvYmzmYnmd3IEifzR61Tragkbx9D3+R8mzQqDBz8v+BvZNDlkiTtI9T15KYZhP0ehn3Dld4n9J5g==}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-win32-ia32-msvc@4.22.4':
     optional: true
 
-  /@rollup/rollup-win32-x64-msvc@4.14.1:
-    resolution: {integrity: sha512-wQGI+LY/Py20zdUPq+XCem7JcPOyzIJBm3dli+56DJsQOHbnXZFEwgmnC6el1TPAfC8lBT3m+z69RmLykNUbew==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-win32-x64-msvc@4.14.1':
     optional: true
 
-  /@rollup/rollup-win32-x64-msvc@4.22.4:
-    resolution: {integrity: sha512-j8pPKp53/lq9lMXN57S8cFz0MynJk8OWNuUnXct/9KCpKU7DgU3bYMJhwWmcqC0UU29p8Lr0/7KEVcaM6bf47Q==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
+  '@rollup/rollup-win32-x64-msvc@4.22.4':
     optional: true
 
-  /@types/estree@1.0.5:
-    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
-    dev: true
+  '@types/estree@1.0.5': {}
 
-  /@types/node@12.20.55:
-    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-    dev: true
+  '@types/node@12.20.55': {}
 
-  /@types/node@20.16.6:
-    resolution: {integrity: sha512-T7PpxM/6yeDE+AdlVysT62BX6/bECZOmQAgiFg5NoBd5MQheZ3tzal7f1wvzfiEcmrcJNRi2zRr2nY2zF+0uqw==}
+  '@types/node@20.16.6':
     dependencies:
       undici-types: 6.19.8
-    dev: true
 
-  /@types/semver@7.5.6:
-    resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
-    dev: true
+  '@types/semver@7.5.6': {}
 
-  /@vitest/expect@2.1.1:
-    resolution: {integrity: sha512-YeueunS0HiHiQxk+KEOnq/QMzlUuOzbU1Go+PgAsHvvv3tUkJPm9xWt+6ITNTlzsMXUjmgm5T+U7KBPK2qQV6w==}
+  '@vitest/expect@2.1.1':
     dependencies:
       '@vitest/spy': 2.1.1
       '@vitest/utils': 2.1.1
       chai: 5.1.1
       tinyrainbow: 1.2.0
-    dev: true
 
-  /@vitest/mocker@2.1.1(@vitest/spy@2.1.1)(vite@5.2.8):
-    resolution: {integrity: sha512-LNN5VwOEdJqCmJ/2XJBywB11DLlkbY0ooDJW3uRX5cZyYCrc4PI/ePX0iQhE3BiEGiQmK4GE7Q/PqCkkaiPnrA==}
-    peerDependencies:
-      '@vitest/spy': 2.1.1
-      msw: ^2.3.5
-      vite: ^5.0.0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
+  '@vitest/mocker@2.1.1(@vitest/spy@2.1.1)(vite@5.2.8)':
     dependencies:
       '@vitest/spy': 2.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.11
       vite: 5.2.8(@types/node@20.16.6)
-    dev: true
 
-  /@vitest/pretty-format@2.1.1:
-    resolution: {integrity: sha512-SjxPFOtuINDUW8/UkElJYQSFtnWX7tMksSGW0vfjxMneFqxVr8YJ979QpMbDW7g+BIiq88RAGDjf7en6rvLPPQ==}
+  '@vitest/pretty-format@2.1.1':
     dependencies:
       tinyrainbow: 1.2.0
-    dev: true
 
-  /@vitest/runner@2.1.1:
-    resolution: {integrity: sha512-uTPuY6PWOYitIkLPidaY5L3t0JJITdGTSwBtwMjKzo5O6RCOEncz9PUN+0pDidX8kTHYjO0EwUIvhlGpnGpxmA==}
+  '@vitest/runner@2.1.1':
     dependencies:
       '@vitest/utils': 2.1.1
       pathe: 1.1.2
-    dev: true
 
-  /@vitest/snapshot@2.1.1:
-    resolution: {integrity: sha512-BnSku1WFy7r4mm96ha2FzN99AZJgpZOWrAhtQfoxjUU5YMRpq1zmHRq7a5K9/NjqonebO7iVDla+VvZS8BOWMw==}
+  '@vitest/snapshot@2.1.1':
     dependencies:
       '@vitest/pretty-format': 2.1.1
       magic-string: 0.30.11
       pathe: 1.1.2
-    dev: true
 
-  /@vitest/spy@2.1.1:
-    resolution: {integrity: sha512-ZM39BnZ9t/xZ/nF4UwRH5il0Sw93QnZXd9NAZGRpIgj0yvVwPpLd702s/Cx955rGaMlyBQkZJ2Ir7qyY48VZ+g==}
+  '@vitest/spy@2.1.1':
     dependencies:
       tinyspy: 3.0.2
-    dev: true
 
-  /@vitest/utils@2.1.1:
-    resolution: {integrity: sha512-Y6Q9TsI+qJ2CC0ZKj6VBb+T8UPz593N113nnUykqwANqhgf3QkZeHFlusgKLTqrnVHbj/XDKZcDHol+dxVT+rQ==}
+  '@vitest/utils@2.1.1':
     dependencies:
       '@vitest/pretty-format': 2.1.1
       loupe: 3.1.1
       tinyrainbow: 1.2.0
-    dev: true
 
-  /ansi-colors@4.1.3:
-    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
-    engines: {node: '>=6'}
-    dev: true
+  ansi-colors@4.1.3: {}
 
-  /ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
-    dev: true
+  ansi-regex@5.0.1: {}
 
-  /ansi-regex@6.0.1:
-    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
-    engines: {node: '>=12'}
-    dev: true
+  ansi-regex@6.0.1: {}
 
-  /ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
+  ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
-  /ansi-styles@6.2.1:
-    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
-    engines: {node: '>=12'}
-    dev: true
+  ansi-styles@6.2.1: {}
 
-  /any-promise@1.3.0:
-    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
-    dev: true
+  any-promise@1.3.0: {}
 
-  /anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
+  anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
-    dev: true
 
-  /argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+  argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
-    dev: true
 
-  /array-union@2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
-    engines: {node: '>=8'}
-    dev: true
+  array-union@2.1.0: {}
 
-  /assertion-error@2.0.1:
-    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
-    engines: {node: '>=12'}
-    dev: true
+  assertion-error@2.0.1: {}
 
-  /balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
+  balanced-match@1.0.2: {}
 
-  /better-path-resolve@1.0.0:
-    resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
-    engines: {node: '>=4'}
+  better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
-    dev: true
 
-  /binary-extensions@2.2.0:
-    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
-    engines: {node: '>=8'}
-    dev: true
+  binary-extensions@2.2.0: {}
 
-  /brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+  brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
-    dev: true
 
-  /braces@3.0.2:
-    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
-    engines: {node: '>=8'}
+  braces@3.0.2:
     dependencies:
       fill-range: 7.0.1
-    dev: true
 
-  /bundle-require@5.0.0(esbuild@0.23.1):
-    resolution: {integrity: sha512-GuziW3fSSmopcx4KRymQEJVbZUfqlCqcq7dvs6TYwKRZiegK/2buMxQTPs6MGlNv50wms1699qYO54R8XfRX4w==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    peerDependencies:
-      esbuild: '>=0.18'
+  bundle-require@5.0.0(esbuild@0.23.1):
     dependencies:
       esbuild: 0.23.1
       load-tsconfig: 0.2.5
-    dev: true
 
-  /cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-    dev: true
+  cac@6.7.14: {}
 
-  /chai@5.1.1:
-    resolution: {integrity: sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==}
-    engines: {node: '>=12'}
+  chai@5.1.1:
     dependencies:
       assertion-error: 2.0.1
       check-error: 2.1.1
       deep-eql: 5.0.2
       loupe: 3.1.1
       pathval: 2.0.0
-    dev: true
 
-  /chardet@0.7.0:
-    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
-    dev: true
+  chardet@0.7.0: {}
 
-  /check-error@2.1.1:
-    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
-    engines: {node: '>= 16'}
-    dev: true
+  check-error@2.1.1: {}
 
-  /chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
+  chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
       braces: 3.0.2
@@ -1314,114 +2136,59 @@ packages:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
-  /ci-info@3.9.0:
-    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
-    engines: {node: '>=8'}
-    dev: true
+  ci-info@3.9.0: {}
 
-  /color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
+  color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
-    dev: true
 
-  /color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
+  color-name@1.1.4: {}
 
-  /commander@4.1.1:
-    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
-    dev: true
+  commander@4.1.1: {}
 
-  /consola@3.2.3:
-    resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
-    engines: {node: ^14.18.0 || >=16.10.0}
-    dev: true
+  consola@3.2.3: {}
 
-  /cross-spawn@5.1.0:
-    resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
+  cross-spawn@5.1.0:
     dependencies:
       lru-cache: 4.1.5
       shebang-command: 1.2.0
       which: 1.3.1
-    dev: true
 
-  /cross-spawn@7.0.3:
-    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
-    engines: {node: '>= 8'}
+  cross-spawn@7.0.3:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-    dev: true
 
-  /dataloader@1.4.0:
-    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
-    dev: true
+  dataloader@1.4.0: {}
 
-  /debug@4.3.7:
-    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
+  debug@4.3.7:
     dependencies:
       ms: 2.1.3
-    dev: true
 
-  /deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
-    dev: true
+  deep-eql@5.0.2: {}
 
-  /detect-indent@6.1.0:
-    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
-    engines: {node: '>=8'}
-    dev: true
+  detect-indent@6.1.0: {}
 
-  /dir-glob@3.0.1:
-    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
-    engines: {node: '>=8'}
+  dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
-    dev: true
 
-  /dotenv@8.6.0:
-    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
-    engines: {node: '>=10'}
-    dev: true
+  dotenv@8.6.0: {}
 
-  /eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-    dev: true
+  eastasianwidth@0.2.0: {}
 
-  /emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-    dev: true
+  emoji-regex@8.0.0: {}
 
-  /emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-    dev: true
+  emoji-regex@9.2.2: {}
 
-  /enquirer@2.4.1:
-    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
-    engines: {node: '>=8.6'}
+  enquirer@2.4.1:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
-    dev: true
 
-  /esbuild@0.20.2:
-    resolution: {integrity: sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
+  esbuild@0.20.2:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.20.2
       '@esbuild/android-arm': 0.20.2
@@ -1446,13 +2213,8 @@ packages:
       '@esbuild/win32-arm64': 0.20.2
       '@esbuild/win32-ia32': 0.20.2
       '@esbuild/win32-x64': 0.20.2
-    dev: true
 
-  /esbuild@0.23.1:
-    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
-    engines: {node: '>=18'}
-    hasBin: true
-    requiresBuild: true
+  esbuild@0.23.1:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.23.1
       '@esbuild/android-arm': 0.23.1
@@ -1478,23 +2240,14 @@ packages:
       '@esbuild/win32-arm64': 0.23.1
       '@esbuild/win32-ia32': 0.23.1
       '@esbuild/win32-x64': 0.23.1
-    dev: true
 
-  /esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-    dev: true
+  esprima@4.0.1: {}
 
-  /estree-walker@3.0.3:
-    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+  estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.5
-    dev: true
 
-  /execa@5.1.1:
-    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
-    engines: {node: '>=10'}
+  execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.3
       get-stream: 6.0.1
@@ -1505,137 +2258,80 @@ packages:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
-    dev: true
 
-  /extendable-error@0.1.7:
-    resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
-    dev: true
+  extendable-error@0.1.7: {}
 
-  /external-editor@3.1.0:
-    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
-    engines: {node: '>=4'}
+  external-editor@3.1.0:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
-    dev: true
 
-  /fast-glob@3.3.2:
-    resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
-    engines: {node: '>=8.6.0'}
+  fast-glob@3.3.2:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
-    dev: true
 
-  /fastq@1.16.0:
-    resolution: {integrity: sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==}
+  fastq@1.16.0:
     dependencies:
       reusify: 1.0.4
-    dev: true
 
-  /fdir@6.3.0(picomatch@4.0.2):
-    resolution: {integrity: sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ==}
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
+  fdir@6.3.0(picomatch@4.0.2):
     dependencies:
       picomatch: 4.0.2
-    dev: true
 
-  /fill-range@7.0.1:
-    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
-    engines: {node: '>=8'}
+  fill-range@7.0.1:
     dependencies:
       to-regex-range: 5.0.1
-    dev: true
 
-  /find-up@4.1.0:
-    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
-    engines: {node: '>=8'}
+  find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
-    dev: true
 
-  /foreground-child@3.1.1:
-    resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
-    engines: {node: '>=14'}
+  foreground-child@3.1.1:
     dependencies:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
-    dev: true
 
-  /fs-extra@7.0.1:
-    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
-    engines: {node: '>=6 <7 || >=8'}
+  fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
-    dev: true
 
-  /fs-extra@8.1.0:
-    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
-    engines: {node: '>=6 <7 || >=8'}
+  fs-extra@8.1.0:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
-    dev: true
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    requiresBuild: true
-    dev: false
+  fsevents@2.3.2:
     optional: true
 
-  /fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    requiresBuild: true
-    dev: true
+  fsevents@2.3.3:
     optional: true
 
-  /get-func-name@2.0.2:
-    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
-    dev: true
+  get-func-name@2.0.2: {}
 
-  /get-stream@6.0.1:
-    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
-    engines: {node: '>=10'}
-    dev: true
+  get-stream@6.0.1: {}
 
-  /glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
+  glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
-    dev: true
 
-  /glob@10.3.10:
-    resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    hasBin: true
+  glob@10.3.10:
     dependencies:
       foreground-child: 3.1.1
       jackspeak: 2.3.6
       minimatch: 9.0.3
       minipass: 7.0.4
       path-scurry: 1.10.1
-    dev: true
 
-  /globby@11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
-    engines: {node: '>=10'}
+  globby@11.1.0:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
@@ -1643,464 +2339,229 @@ packages:
       ignore: 5.3.0
       merge2: 1.4.1
       slash: 3.0.0
-    dev: true
 
-  /graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-    dev: true
+  graceful-fs@4.2.11: {}
 
-  /human-id@1.0.2:
-    resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
-    dev: true
+  human-id@1.0.2: {}
 
-  /human-signals@2.1.0:
-    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
-    engines: {node: '>=10.17.0'}
-    dev: true
+  human-signals@2.1.0: {}
 
-  /iconv-lite@0.4.24:
-    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
-    engines: {node: '>=0.10.0'}
+  iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
-    dev: true
 
-  /ignore@5.3.0:
-    resolution: {integrity: sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==}
-    engines: {node: '>= 4'}
-    dev: true
+  ignore@5.3.0: {}
 
-  /is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
+  is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.2.0
-    dev: true
 
-  /is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
-    dev: true
+  is-extglob@2.1.1: {}
 
-  /is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
-    dev: true
+  is-fullwidth-code-point@3.0.0: {}
 
-  /is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
+  is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
-    dev: true
 
-  /is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
-    dev: true
+  is-number@7.0.0: {}
 
-  /is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
-    dev: true
+  is-stream@2.0.1: {}
 
-  /is-subdir@1.2.0:
-    resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
-    engines: {node: '>=4'}
+  is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
-    dev: true
 
-  /is-windows@1.0.2:
-    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
+  is-windows@1.0.2: {}
 
-  /isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-    dev: true
+  isexe@2.0.0: {}
 
-  /jackspeak@2.3.6:
-    resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
-    engines: {node: '>=14'}
+  jackspeak@2.3.6:
     dependencies:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-    dev: true
 
-  /joycon@3.1.1:
-    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
-    engines: {node: '>=10'}
-    dev: true
+  joycon@3.1.1: {}
 
-  /js-yaml@3.14.1:
-    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
-    hasBin: true
+  js-yaml@3.14.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
-    dev: true
 
-  /jsonfile@4.0.0:
-    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+  jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
-    dev: true
 
-  /lilconfig@3.1.2:
-    resolution: {integrity: sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==}
-    engines: {node: '>=14'}
-    dev: true
+  lilconfig@3.1.2: {}
 
-  /lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
-    dev: true
+  lines-and-columns@1.2.4: {}
 
-  /load-tsconfig@0.2.5:
-    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: true
+  load-tsconfig@0.2.5: {}
 
-  /locate-path@5.0.0:
-    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
-    engines: {node: '>=8'}
+  locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
-    dev: true
 
-  /lodash.sortby@4.7.0:
-    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
-    dev: true
+  lodash.sortby@4.7.0: {}
 
-  /lodash.startcase@4.4.0:
-    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
-    dev: true
+  lodash.startcase@4.4.0: {}
 
-  /loupe@3.1.1:
-    resolution: {integrity: sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==}
+  loupe@3.1.1:
     dependencies:
       get-func-name: 2.0.2
-    dev: true
 
-  /lru-cache@10.1.0:
-    resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
-    engines: {node: 14 || >=16.14}
-    dev: true
+  lru-cache@10.1.0: {}
 
-  /lru-cache@4.1.5:
-    resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
+  lru-cache@4.1.5:
     dependencies:
       pseudomap: 1.0.2
       yallist: 2.1.2
-    dev: true
 
-  /lru-cache@6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
+  lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
-    dev: true
 
-  /magic-string@0.30.11:
-    resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
+  magic-string@0.30.11:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-    dev: true
 
-  /merge-stream@2.0.0:
-    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
-    dev: true
+  merge-stream@2.0.0: {}
 
-  /merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
-    dev: true
+  merge2@1.4.1: {}
 
-  /micromatch@4.0.5:
-    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
-    engines: {node: '>=8.6'}
+  micromatch@4.0.5:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
-    dev: true
 
-  /mimic-fn@2.1.0:
-    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
-    engines: {node: '>=6'}
-    dev: true
+  mimic-fn@2.1.0: {}
 
-  /minimatch@9.0.3:
-    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  minimatch@9.0.3:
     dependencies:
       brace-expansion: 2.0.1
-    dev: true
 
-  /minipass@7.0.4:
-    resolution: {integrity: sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dev: true
+  minipass@7.0.4: {}
 
-  /mri@1.2.0:
-    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
-    engines: {node: '>=4'}
-    dev: true
+  mri@1.2.0: {}
 
-  /ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-    dev: true
+  ms@2.1.3: {}
 
-  /mz@2.7.0:
-    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+  mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
-    dev: true
 
-  /nanoid@3.3.7:
-    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-    dev: true
+  nanoid@3.3.7: {}
 
-  /node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
+  node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
-    dev: true
 
-  /normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
+  normalize-path@3.0.0: {}
 
-  /npm-run-path@4.0.1:
-    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
-    engines: {node: '>=8'}
+  npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
-    dev: true
 
-  /object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-    dev: true
+  object-assign@4.1.1: {}
 
-  /onetime@5.1.2:
-    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
-    engines: {node: '>=6'}
+  onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
-    dev: true
 
-  /os-tmpdir@1.0.2:
-    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
-    engines: {node: '>=0.10.0'}
-    dev: true
+  os-tmpdir@1.0.2: {}
 
-  /outdent@0.5.0:
-    resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
-    dev: true
+  outdent@0.5.0: {}
 
-  /p-filter@2.1.0:
-    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
-    engines: {node: '>=8'}
+  p-filter@2.1.0:
     dependencies:
       p-map: 2.1.0
-    dev: true
 
-  /p-limit@2.3.0:
-    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
-    engines: {node: '>=6'}
+  p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
-    dev: true
 
-  /p-locate@4.1.0:
-    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
-    engines: {node: '>=8'}
+  p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
-    dev: true
 
-  /p-map@2.1.0:
-    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
-    engines: {node: '>=6'}
-    dev: true
+  p-map@2.1.0: {}
 
-  /p-try@2.2.0:
-    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
-    engines: {node: '>=6'}
-    dev: true
+  p-try@2.2.0: {}
 
-  /package-manager-detector@0.2.0:
-    resolution: {integrity: sha512-E385OSk9qDcXhcM9LNSe4sdhx8a9mAPrZ4sMLW+tmxl5ZuGtPUcdFu+MPP2jbgiWAZ6Pfe5soGFMd+0Db5Vrog==}
-    dev: true
+  package-manager-detector@0.2.0: {}
 
-  /path-exists@4.0.0:
-    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
-    engines: {node: '>=8'}
-    dev: true
+  path-exists@4.0.0: {}
 
-  /path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
-    dev: true
+  path-key@3.1.1: {}
 
-  /path-scurry@1.10.1:
-    resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  path-scurry@1.10.1:
     dependencies:
       lru-cache: 10.1.0
       minipass: 7.0.4
-    dev: true
 
-  /path-type@4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
-    engines: {node: '>=8'}
-    dev: true
+  path-type@4.0.0: {}
 
-  /pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
-    dev: true
+  pathe@1.1.2: {}
 
-  /pathval@2.0.0:
-    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
-    engines: {node: '>= 14.16'}
-    dev: true
+  pathval@2.0.0: {}
 
-  /picocolors@1.1.0:
-    resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
-    dev: true
+  picocolors@1.1.0: {}
 
-  /picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
-    dev: true
+  picomatch@2.3.1: {}
 
-  /picomatch@4.0.2:
-    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
-    engines: {node: '>=12'}
-    dev: true
+  picomatch@4.0.2: {}
 
-  /pify@4.0.1:
-    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
-    engines: {node: '>=6'}
-    dev: true
+  pify@4.0.1: {}
 
-  /pirates@4.0.6:
-    resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
-    engines: {node: '>= 6'}
-    dev: true
+  pirates@4.0.6: {}
 
-  /playwright-core@1.47.1:
-    resolution: {integrity: sha512-i1iyJdLftqtt51mEk6AhYFaAJCDx0xQ/O5NU8EKaWFgMjItPVma542Nh/Aq8aLCjIJSzjaiEQGW/nyqLkGF1OQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-    dev: false
+  playwright-core@1.47.1: {}
 
-  /playwright@1.47.1:
-    resolution: {integrity: sha512-SUEKi6947IqYbKxRiqnbUobVZY4bF1uu+ZnZNJX9DfU1tlf2UhWfvVjLf01pQx9URsOr18bFVUKXmanYWhbfkw==}
-    engines: {node: '>=18'}
-    hasBin: true
+  playwright@1.47.1:
     dependencies:
       playwright-core: 1.47.1
     optionalDependencies:
       fsevents: 2.3.2
-    dev: false
 
-  /postcss-load-config@6.0.1:
-    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      jiti:
-        optional: true
-      postcss:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
+  postcss-load-config@6.0.1:
     dependencies:
       lilconfig: 3.1.2
-    dev: true
 
-  /postcss@8.4.38:
-    resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
-    engines: {node: ^10 || ^12 || >=14}
+  postcss@8.4.38:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.1.0
       source-map-js: 1.2.0
-    dev: true
 
-  /prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    dev: true
+  prettier@2.8.8: {}
 
-  /pseudomap@1.0.2:
-    resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
-    dev: true
+  pseudomap@1.0.2: {}
 
-  /punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
-    engines: {node: '>=6'}
-    dev: true
+  punycode@2.3.1: {}
 
-  /queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-    dev: true
+  queue-microtask@1.2.3: {}
 
-  /read-yaml-file@1.1.0:
-    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
-    engines: {node: '>=6'}
+  read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
-    dev: true
 
-  /readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
+  readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
-    dev: true
 
-  /regenerator-runtime@0.14.1:
-    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
-    dev: true
+  regenerator-runtime@0.14.1: {}
 
-  /resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
-    engines: {node: '>=8'}
-    dev: true
+  resolve-from@5.0.0: {}
 
-  /reusify@1.0.4:
-    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-    dev: true
+  reusify@1.0.4: {}
 
-  /rollup@4.14.1:
-    resolution: {integrity: sha512-4LnHSdd3QK2pa1J6dFbfm1HN0D7vSK/ZuZTsdyUAlA6Rr1yTouUTL13HaDOGJVgby461AhrNGBS7sCGXXtT+SA==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
+  rollup@4.14.1:
     dependencies:
       '@types/estree': 1.0.5
     optionalDependencies:
@@ -2120,12 +2581,8 @@ packages:
       '@rollup/rollup-win32-ia32-msvc': 4.14.1
       '@rollup/rollup-win32-x64-msvc': 4.14.1
       fsevents: 2.3.3
-    dev: true
 
-  /rollup@4.22.4:
-    resolution: {integrity: sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
+  rollup@4.22.4:
     dependencies:
       '@types/estree': 1.0.5
     optionalDependencies:
@@ -2146,145 +2603,79 @@ packages:
       '@rollup/rollup-win32-ia32-msvc': 4.22.4
       '@rollup/rollup-win32-x64-msvc': 4.22.4
       fsevents: 2.3.3
-    dev: true
 
-  /run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+  run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
-    dev: true
 
-  /safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-    dev: true
+  safer-buffer@2.1.2: {}
 
-  /semver@7.5.4:
-    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
-    engines: {node: '>=10'}
-    hasBin: true
+  semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
-  /shebang-command@1.2.0:
-    resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
-    engines: {node: '>=0.10.0'}
+  shebang-command@1.2.0:
     dependencies:
       shebang-regex: 1.0.0
-    dev: true
 
-  /shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
+  shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
-    dev: true
 
-  /shebang-regex@1.0.0:
-    resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
-    engines: {node: '>=0.10.0'}
-    dev: true
+  shebang-regex@1.0.0: {}
 
-  /shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
-    dev: true
+  shebang-regex@3.0.0: {}
 
-  /siginfo@2.0.0:
-    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-    dev: true
+  siginfo@2.0.0: {}
 
-  /signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-    dev: true
+  signal-exit@3.0.7: {}
 
-  /signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
-    dev: true
+  signal-exit@4.1.0: {}
 
-  /slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
-    engines: {node: '>=8'}
-    dev: true
+  slash@3.0.0: {}
 
-  /source-map-js@1.2.0:
-    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
-    engines: {node: '>=0.10.0'}
-    dev: true
+  source-map-js@1.2.0: {}
 
-  /source-map@0.8.0-beta.0:
-    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
-    engines: {node: '>= 8'}
+  source-map@0.8.0-beta.0:
     dependencies:
       whatwg-url: 7.1.0
-    dev: true
 
-  /spawndamnit@2.0.0:
-    resolution: {integrity: sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==}
+  spawndamnit@2.0.0:
     dependencies:
       cross-spawn: 5.1.0
       signal-exit: 3.0.7
-    dev: true
 
-  /sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-    dev: true
+  sprintf-js@1.0.3: {}
 
-  /stackback@0.0.2:
-    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
-    dev: true
+  stackback@0.0.2: {}
 
-  /std-env@3.7.0:
-    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
-    dev: true
+  std-env@3.7.0: {}
 
-  /string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
+  string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-    dev: true
 
-  /string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
+  string-width@5.1.2:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
-    dev: true
 
-  /strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
+  strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
-    dev: true
 
-  /strip-ansi@7.1.0:
-    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
-    engines: {node: '>=12'}
+  strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.0.1
-    dev: true
 
-  /strip-bom@3.0.0:
-    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
-    engines: {node: '>=4'}
-    dev: true
+  strip-bom@3.0.0: {}
 
-  /strip-final-newline@2.0.0:
-    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
-    engines: {node: '>=6'}
-    dev: true
+  strip-final-newline@2.0.0: {}
 
-  /sucrase@3.35.0:
-    resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    hasBin: true
+  sucrase@3.35.0:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       commander: 4.1.1
@@ -2293,108 +2684,51 @@ packages:
       mz: 2.7.0
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
-    dev: true
 
-  /term-size@2.2.1:
-    resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
-    engines: {node: '>=8'}
-    dev: true
+  term-size@2.2.1: {}
 
-  /thenify-all@1.6.0:
-    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
-    engines: {node: '>=0.8'}
+  thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
-    dev: true
 
-  /thenify@3.3.1:
-    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+  thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
-    dev: true
 
-  /tinybench@2.9.0:
-    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
-    dev: true
+  tinybench@2.9.0: {}
 
-  /tinyexec@0.3.0:
-    resolution: {integrity: sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==}
-    dev: true
+  tinyexec@0.3.0: {}
 
-  /tinyglobby@0.2.6:
-    resolution: {integrity: sha512-NbBoFBpqfcgd1tCiO8Lkfdk+xrA7mlLR9zgvZcZWQQwU63XAfUePyd6wZBaU93Hqw347lHnwFzttAkemHzzz4g==}
-    engines: {node: '>=12.0.0'}
+  tinyglobby@0.2.6:
     dependencies:
       fdir: 6.3.0(picomatch@4.0.2)
       picomatch: 4.0.2
-    dev: true
 
-  /tinypool@1.0.1:
-    resolution: {integrity: sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    dev: true
+  tinypool@1.0.1: {}
 
-  /tinyrainbow@1.2.0:
-    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
-    engines: {node: '>=14.0.0'}
-    dev: true
+  tinyrainbow@1.2.0: {}
 
-  /tinyspy@3.0.2:
-    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
-    engines: {node: '>=14.0.0'}
-    dev: true
+  tinyspy@3.0.2: {}
 
-  /tmp@0.0.33:
-    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
-    engines: {node: '>=0.6.0'}
+  tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
-    dev: true
 
-  /to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
+  to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-    dev: true
 
-  /tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: true
+  tr46@0.0.3: {}
 
-  /tr46@1.0.1:
-    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+  tr46@1.0.1:
     dependencies:
       punycode: 2.3.1
-    dev: true
 
-  /tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
-    hasBin: true
-    dev: true
+  tree-kill@1.2.2: {}
 
-  /ts-interface-checker@0.1.13:
-    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
-    dev: true
+  ts-interface-checker@0.1.13: {}
 
-  /tsup@8.3.0(typescript@5.6.2):
-    resolution: {integrity: sha512-ALscEeyS03IomcuNdFdc0YWGVIkwH1Ws7nfTbAPuoILvEV2hpGQAY72LIOjglGo4ShWpZfpBqP/jpQVCzqYQag==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      '@microsoft/api-extractor': ^7.36.0
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.5.0'
-    peerDependenciesMeta:
-      '@microsoft/api-extractor':
-        optional: true
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
+  tsup@8.3.0(typescript@5.6.2):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.1)
       cac: 6.7.14
@@ -2418,27 +2752,14 @@ packages:
       - supports-color
       - tsx
       - yaml
-    dev: true
 
-  /typescript@5.6.2:
-    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
+  typescript@5.6.2: {}
 
-  /undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
-    dev: true
+  undici-types@6.19.8: {}
 
-  /universalify@0.1.2:
-    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
-    engines: {node: '>= 4.0.0'}
-    dev: true
+  universalify@0.1.2: {}
 
-  /vite-node@2.1.1(@types/node@20.16.6):
-    resolution: {integrity: sha512-N/mGckI1suG/5wQI35XeR9rsMsPqKXzq1CdUndzVstBj/HvyxxGctwnK6WX43NGt5L3Z5tcRf83g4TITKJhPrA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
+  vite-node@2.1.1(@types/node@20.16.6):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7
@@ -2453,35 +2774,8 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
 
-  /vite@5.2.8(@types/node@20.16.6):
-    resolution: {integrity: sha512-OyZR+c1CE8yeHw5V5t59aXsUPPVTHMDjEZz8MgguLL/Q7NblxhZUlTu9xSPqlsUO/y+X7dlU05jdhvyycD55DA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
+  vite@5.2.8(@types/node@20.16.6):
     dependencies:
       '@types/node': 20.16.6
       esbuild: 0.20.2
@@ -2489,32 +2783,8 @@ packages:
       rollup: 4.14.1
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
-  /vitest@2.1.1(@types/node@20.16.6):
-    resolution: {integrity: sha512-97We7/VC0e9X5zBVkvt7SGQMGrRtn3KtySFQG5fpaMlS+l62eeXRQO633AYhSTC3z7IMebnPPNjGXVGNRFlxBA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.1
-      '@vitest/ui': 2.1.1
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
+  vitest@2.1.1(@types/node@20.16.6):
     dependencies:
       '@types/node': 20.16.6
       '@vitest/expect': 2.1.1
@@ -2545,77 +2815,47 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
 
-  /webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: true
+  webidl-conversions@3.0.1: {}
 
-  /webidl-conversions@4.0.2:
-    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
-    dev: true
+  webidl-conversions@4.0.2: {}
 
-  /whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+  whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    dev: true
 
-  /whatwg-url@7.1.0:
-    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
+  whatwg-url@7.1.0:
     dependencies:
       lodash.sortby: 4.7.0
       tr46: 1.0.1
       webidl-conversions: 4.0.2
-    dev: true
 
-  /which@1.3.1:
-    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
-    hasBin: true
+  which@1.3.1:
     dependencies:
       isexe: 2.0.0
-    dev: true
 
-  /which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
+  which@2.0.2:
     dependencies:
       isexe: 2.0.0
-    dev: true
 
-  /why-is-node-running@2.3.0:
-    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
-    engines: {node: '>=8'}
-    hasBin: true
+  why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-    dev: true
 
-  /wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
+  wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
 
-  /wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
+  wrap-ansi@8.1.0:
     dependencies:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
-    dev: true
 
-  /yallist@2.1.2:
-    resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
-    dev: true
+  yallist@2.1.2: {}
 
-  /yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: true
+  yallist@4.0.0: {}

--- a/src/basePage.ts
+++ b/src/basePage.ts
@@ -4,12 +4,15 @@ import type { PlaywrightReportLogger } from "./helpers/playwrightReportLogger";
 import { SessionStorage } from "./helpers/sessionStorage.actions";
 import { createCypressIdEngine } from "./utils/selectorEngines";
 
+/**
+ * BasePageOptions can define optional patterns for baseUrl and urlPath.
+ * Defaults assume they are strings if not specified.
+ */
 export type BasePageOptions = {
 	urlOptions?: {
 		baseUrlType?: string | RegExp; // Optional, defaults to string
 		urlPathType?: string | RegExp; // Optional, defaults to string
 	};
-	// Other future options can go here
 };
 
 export type ExtractBaseUrlType<T extends BasePageOptions> = T["urlOptions"] extends { baseUrlType: RegExp }
@@ -26,10 +29,27 @@ export type ExtractFullUrlType<T extends BasePageOptions> = T["urlOptions"] exte
 
 let selectorRegistered = false;
 
-/** The BasePage class, extended by all Page Object Classes */
+/**
+ * BasePage:
+ * The foundational class for all Page Object Classes.
+ *
+ * Generics:
+ * - LocatorSchemaPathType: A union of valid locator paths.
+ * - Options: Configuration type for URLs.
+ * - LocatorSubstring: The chosen substring locator.
+ *
+ * We instantiate GetLocatorBase with these generics. When calling getLocatorSchema,
+ * the chosen path P sets LocatorSubstring = P, ensuring methods like addFilter only suggests valid sub-paths.
+ *
+ * BasePage provides:
+ * - Common properties: page, testInfo, selectors, URLs, logging, sessionStorage.
+ * - getNestedLocator & getLocator methods that delegate to getLocatorSchema.
+ * - Abstract initLocatorSchemas method to be implemented by concrete POCs.
+ */
 export abstract class BasePage<
 	LocatorSchemaPathType extends string,
 	Options extends BasePageOptions = { urlOptions: { baseUrlType: string; urlPathType: string } },
+	LocatorSubstring extends LocatorSchemaPathType | undefined = undefined,
 > {
 	/** Provides Playwright page methods */
 	page: Page;
@@ -41,14 +61,12 @@ export abstract class BasePage<
 	selector: Selectors;
 
 	/** The base URL of the Page Object Class */
-	// baseUrl: string;
 	baseUrl: ExtractBaseUrlType<Options>;
 
 	/** The URL path of the Page Object Class */
-	// urlPath: string;
 	urlPath: ExtractUrlPathType<Options>;
 
-	// fullUrl: string;
+	/** The full URL of the Page Object Class */
 	fullUrl: ExtractFullUrlType<Options>;
 
 	/** The name of the Page Object Class */
@@ -60,7 +78,13 @@ export abstract class BasePage<
 	/** The SessionStorage class provides methods for setting and getting session storage data in Playwright.*/
 	sessionStorage: SessionStorage;
 
-	protected locators: GetLocatorBase<LocatorSchemaPathType>;
+	/**
+	 * locators:
+	 * An instance of GetLocatorBase that handles schema management and provides getLocatorSchema calls.
+	 * Initially, LocatorSubstring is undefined. Once getLocatorSchema(path) is called,
+	 * we get a chainable object typed with LocatorSubstring = P.
+	 */
+	protected locators: GetLocatorBase<LocatorSchemaPathType, LocatorSubstring>;
 
 	constructor(
 		page: Page,
@@ -69,6 +93,7 @@ export abstract class BasePage<
 		urlPath: ExtractUrlPathType<Options>,
 		pocName: string,
 		pwrl: PlaywrightReportLogger,
+		locatorSubstring?: LocatorSubstring,
 	) {
 		this.page = page;
 		this.testInfo = testInfo;
@@ -76,22 +101,33 @@ export abstract class BasePage<
 
 		this.baseUrl = baseUrl;
 		this.urlPath = urlPath;
-		this.fullUrl = this.constructFullUrl(baseUrl, urlPath); //`${this.baseUrl}${this.urlPath}`;
+		this.fullUrl = this.constructFullUrl(baseUrl, urlPath); // `${this.baseUrl}${this.urlPath}`
 		this.pocName = pocName;
 
 		this.log = pwrl.getNewChildLogger(pocName);
-		this.locators = new GetLocatorBase<LocatorSchemaPathType>(this, this.log.getNewChildLogger("GetLocator"));
+
+		// Instantiate GetLocatorBase following the minimal POC pattern.
+		this.locators = new GetLocatorBase<LocatorSchemaPathType, LocatorSubstring>(
+			this,
+			this.log.getNewChildLogger("GetLocator"),
+			locatorSubstring,
+		);
 		this.initLocatorSchemas();
 
 		this.sessionStorage = new SessionStorage(this.page, this.pocName);
 
-		/** Register custom Playwright Selector Engines here. A custom Selector Engine must only be registered once! */
+		// Register a custom selector engine once globally.
 		if (!selectorRegistered) {
 			selectors.register("data-cy", createCypressIdEngine);
 			selectorRegistered = true;
 		}
 	}
 
+	/**
+	 * constructFullUrl:
+	 * Combines baseUrl and urlPath, handling both strings and RegExps.
+	 * Ensures a flexible approach to URL matching (string or regex-based).
+	 */
 	private constructFullUrl(
 		baseUrl: ExtractBaseUrlType<Options>,
 		urlPath: ExtractUrlPathType<Options>,
@@ -122,7 +158,8 @@ export abstract class BasePage<
 	}
 
 	/**
-	 * getNestedLocator(indices?: { [key: number]: number | null } | null)
+	 * getNestedLocator:
+	 * Delegates to getLocatorSchema(...).getNestedLocator(indices).
 	 * - Asynchronously retrieves a nested locator based on the LocatorSchemaPath provided by getLocatorSchema("...")
 	 * - Can be chained after the update and updates methods, getNestedLocator will end the chain.
 	 * - The optional parameter of the method takes an object with 0-based indices "{0: 0, 3: 1}" for one or more locators
@@ -131,13 +168,14 @@ export abstract class BasePage<
 	 */
 	public getNestedLocator = async (
 		locatorSchemaPath: LocatorSchemaPathType,
-		indices?: { [key: number]: number | null } | null,
+		indices?: Record<number, number>,
 	): Promise<Locator> => {
 		return await this.getLocatorSchema(locatorSchemaPath).getNestedLocator(indices);
 	};
 
 	/**
-	 * getLocator()
+	 * getLocator:
+	 * Delegates to getLocatorSchema(...).getLocator().
 	 * - Asynchronously retrieves a locator based on the current LocatorSchema. This method does not perform nesting,
 	 * and will return the locator for which the full LocatorSchemaPath resolves to, provided by getLocatorSchema("...")
 	 * - Can be chained after the update and updates methods, getLocator will end the chain.
@@ -148,10 +186,74 @@ export abstract class BasePage<
 	};
 
 	/**
-	 * Abstract method to initialize locator schemas.
+	 * getLocatorSchema:
+	 * Delegates to this.locators.getLocatorSchema.
+	 * Returns a chainable schema object for the given path.
+	 * Once called with a specific path P, addFilter is restricted to sub-paths of P.
+	 *
+	 * The "getLocatorSchema" method is used to retrieve an updatable deep copy of a LocatorSchema defined in the
+	 * GetLocatorBase class. It enriches the returned schema with additional methods to handle updates and retrieval of
+	 * deep copy locators.
+	 *
+	 * getLocatorSchema adds the following chainable methods to the returned LocatorSchemaWithMethods object:
+	 *
+	 * update(updates: Partial< UpdatableLocatorSchemaProperties >)
+	 * - Allows updating the properties of the LocatorSchema which the full LocatorSchemaPath resolves to.
+	 * - This method is used for modifying the current schema without affecting the original schema.
+	 * - Takes a "LocatorSchema" object which omits the locatorSchemaPath parameter as input, the parameters provided
+	 * will overwrite the corresponding property in the current schema.
+	 * - Returns the updated deep copy of the "LocatorSchema" with methods.
+	 * - Can be chained with the update and updates methods, and the getLocator or getNestedLocator method.
+	 *
+	 * updates(indexedUpdates: { [index: number]: Partial< UpdatableLocatorSchemaProperties > | null }):
+	 * - Similar to update, but allows updating any locator in the nested chain (all sub-paths of the LocatorSchemaPath).
+	 * - This method can modify the current deep copy of each LocatorSchema that each sub-path resolves to without
+	 * affecting the original schemas
+	 * - Takes an object where keys represent the index of the last "word" of a sub-path, where the value per key is a
+	 * "LocatorSchema" object which omits the locatorSchemaPath parameter as input, the parameters provided will overwrite
+	 * the corresponding property in the given schema.
+	 * - Returns the updated deep copy of the LocatorSchema object with methods and its own updated deep copies for all
+	 * LocatorSchema each sub-path resolved to.
+	 * - Can be chained with the update and updates methods, and the getLocator or getNestedLocator method.
+	 *
+	 * addFilter(subPath: SubPaths<LocatorSchemaPathType, LocatorSubstring>, filterData: FilterEntry)
+	 * The equivalent of the Playwright locator.filter() method
+	 * - This method is used for filtering the specified locator based on the provided filterData.
+	 *
+	 * getNestedLocator(indices?: { [key: number]: number | null } | null)
+	 * - Asynchronously retrieves a nested locator based on the LocatorSchemaPath provided by getLocatorSchema("...")
+	 * - Can be chained after the update and updates methods, getNestedLocator will end the chain.
+	 * - The optional parameter of the method takes an object with 0-based indices "{0: 0, 3: 1}" for one or more locators
+	 * to be nested given by sub-paths (indices correspond to last "word" of a sub-path).
+	 * - Returns a promise that resolves to the nested locator.
+	 *
+	 * getLocator()
+	 * - Asynchronously retrieves a locator based on the current LocatorSchema. This method does not perform nesting,
+	 * and will return the locator for which the full LocatorSchemaPath resolves to, provided by getLocatorSchema("...")
+	 * - Can be chained after the update and updates methods, getLocator will end the chain.
+	 * - Returns a promise that resolves to the locator.
+	 *
+	 * Note: Calling getLocator() and getNestedLocator() on the same LocatorSchemaPath will return a Locator for the same
+	 * element, but the Locator returned by getNestedLocator() will be a locator resolving to said same element through
+	 * a chain of locators. While the Locator returned by getLocator() will be a single locator which resolves directly
+	 * to said element. Thus getLocator() is rarely used, while getNestedLocator() is used extensively.
+	 *
+	 * That said, for certain use cases, getLocator() can be useful, and you could use it to manually chain locators
+	 * yourself if some edge case required it. Though, it would be likely be more prudent to expand your LocatorSchemaPath
+	 * type and initLocatorSchemas() method to include the additional locators you need for the given POC, and then use
+	 * getNestedLocator() instead.
+	 */
+	public getLocatorSchema<P extends LocatorSchemaPathType>(path: P) {
+		return this.locators.getLocatorSchema(path);
+	}
+
+	/**
+	 * initLocatorSchemas:
+	 * Abstract method to be implemented by each POC.
+	 * POCs define their own type LocatorSchemaPath and add their schemas using locators.addSchema(...).
 	 *
 	 * Each Page Object Class (POC) extending BasePage should define its own
-	 * LocatorSchemaPathType, which is a string type using dot (".") notation.
+	 * LocatorSchemaPath type, which is a string type using dot (".") notation.
 	 * The format should start and end with a word, and words should be separated by dots.
 	 * For example: "section.subsection.element".
 	 *
@@ -227,57 +329,4 @@ export abstract class BasePage<
 	 * }
 	 */
 	protected abstract initLocatorSchemas(): void;
-
-	/**
-	 * The "getLocatorSchema" method is used to retrieve an updatable deep copy of a LocatorSchema defined in the
-	 * GetLocatorBase class. It enriches the returned schema with additional methods to handle updates and retrieval of
-	 * deep copy locators.
-	 *
-	 * getLocatorSchema adds the following chainable methods to the returned LocatorSchemaWithMethods object:
-	 *
-	 * update(updates: Partial< UpdatableLocatorSchemaProperties >)
-	 * - Allows updating the properties of the LocatorSchema which the full LocatorSchemaPath resolves to.
-	 * - This method is used for modifying the current schema without affecting the original schema.
-	 * - Takes a "LocatorSchema" object which omits the locatorSchemaPath parameter as input, the parameters provided
-	 * will overwrite the corresponding property in the current schema.
-	 * - Returns the updated deep copy of the "LocatorSchema" with methods.
-	 * - Can be chained with the update and updates methods, and the getLocator or getNestedLocator method.
-	 *
-	 * updates(indexedUpdates: { [index: number]: Partial< UpdatableLocatorSchemaProperties > | null }):
-	 * - Similar to update, but allows updating any locator in the nested chain (all sub-paths of the LocatorSchemaPath).
-	 * - This method can modify the current deep copy of each LocatorSchema that each sub-path resolves to without
-	 * affecting the original schemas
-	 * - Takes an object where keys represent the index of the last "word" of a sub-path, where the value per key is a
-	 * "LocatorSchema" object which omits the locatorSchemaPath parameter as input, the parameters provided will overwrite
-	 * the corresponding property in the given schema.
-	 * - Returns the updated deep copy of the LocatorSchema object with methods and its own updated deep copies for all
-	 * LocatorSchema each sub-path resolved to.
-	 * - Can be chained with the update and updates methods, and the getLocator or getNestedLocator method.
-	 *
-	 * getNestedLocator(indices?: { [key: number]: number | null } | null)
-	 * - Asynchronously retrieves a nested locator based on the LocatorSchemaPath provided by getLocatorSchema("...")
-	 * - Can be chained after the update and updates methods, getNestedLocator will end the chain.
-	 * - The optional parameter of the method takes an object with 0-based indices "{0: 0, 3: 1}" for one or more locators
-	 * to be nested given by sub-paths (indices correspond to last "word" of a sub-path).
-	 * - Returns a promise that resolves to the nested locator.
-	 *
-	 * getLocator()
-	 * - Asynchronously retrieves a locator based on the current LocatorSchema. This method does not perform nesting,
-	 * and will return the locator for which the full LocatorSchemaPath resolves to, provided by getLocatorSchema("...")
-	 * - Can be chained after the update and updates methods, getLocator will end the chain.
-	 * - Returns a promise that resolves to the locator.
-	 *
-	 * Note: Calling getLocator() and getNestedLocator() on the same LocatorSchemaPath will return a Locator for the same
-	 * element, but the Locator returned by getNestedLocator() will be a locator resolving to said same element through
-	 * a chain of locators. While the Locator returned by getLocator() will be a single locator which resolves directly
-	 * to said element. Thus getLocator() is rarely used, while getNestedLocator() is used extensively.
-	 *
-	 * That said, for certain use cases, getLocator() can be useful, and you could use it to manually chain locators
-	 * yourself if some edge case required it. Though, it would be likely be more prudent to expand your LocatorSchemaPath
-	 * type and initLocatorSchemas() method to include the additional locators you need for the given POC, and then use
-	 * getNestedLocator() instead.
-	 */
-	public getLocatorSchema(locatorSchemaPath: LocatorSchemaPathType) {
-		return this.locators.getLocatorSchema(locatorSchemaPath);
-	}
 }

--- a/src/helpers/getLocatorBase.ts
+++ b/src/helpers/getLocatorBase.ts
@@ -444,16 +444,19 @@ export class GetLocatorBase<LocatorSchemaPathType extends string> {
 				try {
 					const nextLocator = this.getBy.getLocator(currentSchema);
 
-					if (currentLocator) {
-						currentLocator = currentLocator.locator(nextLocator);
-						if (index != null) {
-							currentLocator = currentLocator.nth(index);
-						}
-					} else {
-						currentLocator = nextLocator;
-						if (index != null) {
-							currentLocator = currentLocator.nth(index);
-						}
+					currentLocator = currentLocator ? currentLocator.locator(nextLocator) : nextLocator;
+
+					if (currentSchema.locatorMethod !== GetByMethod.frameLocator && currentSchema.filter) {
+						currentLocator = currentLocator.filter({
+							has: currentSchema.filter.has,
+							hasNot: currentSchema.filter.hasNot,
+							hasNotText: currentSchema.filter.hasNotText,
+							hasText: currentSchema.filter.hasText,
+						});
+					}
+
+					if (index != null) {
+						currentLocator = currentLocator.nth(index);
 					}
 
 					if (this.log.isLogLevelEnabled("debug")) {

--- a/src/helpers/locatorSchema.interface.ts
+++ b/src/helpers/locatorSchema.interface.ts
@@ -101,6 +101,13 @@ export interface LocatorSchema {
 	dataCy?: string;
 	/** The ID of the element. 'id' string format: "value", or a regex expression of the value */
 	id?: string | RegExp;
+	/** The equivalent of the Playwright locator.filter() method */
+	filter?: {
+		has?: Locator;
+		hasNot?: Locator;
+		hasNotText?: string | RegExp;
+		hasText?: string | RegExp;
+	};
 	/** Defines the preferred Playwright locator method to be used on this LocatorSchema Object */
 	locatorMethod: GetByMethod;
 	/** The human-readable name of the defined locator object, used for debug logging and test report enrichment. */
@@ -165,6 +172,12 @@ const locatorSchemaDummy: Partial<LocatorSchema> = {
 	testId: undefined as unknown as string | RegExp,
 	dataCy: undefined as unknown as string,
 	id: undefined as unknown as string | RegExp,
+	filter: {
+		has: undefined as unknown as Locator,
+		hasNot: undefined as unknown as Locator,
+		hasNotText: undefined as unknown as string | RegExp,
+		hasText: undefined as unknown as string | RegExp,
+	},
 	locatorMethod: undefined as unknown as GetByMethod,
 	locatorSchemaPath: undefined as unknown as string,
 };

--- a/test/basePage.test.poc.ts
+++ b/test/basePage.test.poc.ts
@@ -1,5 +1,5 @@
-import { type Page, type TestInfo } from "@playwright/test";
-import { BasePage, GetByMethod, GetLocatorBase, PlaywrightReportLogger } from "../index";
+import type { Page, TestInfo } from "@playwright/test";
+import { BasePage, GetByMethod, type GetLocatorBase, type PlaywrightReportLogger } from "../index";
 
 export type LocatorSchemaPath =
 	| "getByRole"

--- a/test/basePage.test.ts
+++ b/test/basePage.test.ts
@@ -1,4 +1,4 @@
-import { type Page, type TestInfo } from "@playwright/test";
+import type { Page, TestInfo } from "@playwright/test";
 import { beforeEach, describe, expect, test } from "vitest";
 import { PlaywrightReportLogger } from "../index";
 import { getLocatorSchemaDummy } from "../src/helpers/locatorSchema.interface";
@@ -216,6 +216,8 @@ const baseExpectedProperties = [
 	"schemasMap",
 	"update",
 	"updates",
+	"addFilter",
+	"filterMap",
 	"getNestedLocator",
 	"getLocator",
 ];
@@ -356,6 +358,7 @@ describe("BasePage: PageObjectModel.getLocatorSchema", () => {
 			const hasMethods =
 				typeof locatorSchemaWithMethods.update === "function" &&
 				typeof locatorSchemaWithMethods.updates === "function" &&
+				typeof locatorSchemaWithMethods.addFilter === "function" &&
 				typeof locatorSchemaWithMethods.getNestedLocator === "function" &&
 				typeof locatorSchemaWithMethods.getLocator === "function";
 			expect(hasMethods).toBe(true);

--- a/test/helpers/getLocatorBase.test.ts
+++ b/test/helpers/getLocatorBase.test.ts
@@ -1,7 +1,7 @@
 import type { Locator, Page, TestInfo } from "@playwright/test";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { GetByMethod, GetLocatorBase, PlaywrightReportLogger } from "../../index";
-import type { ModifiedLocatorSchema } from "../../src/helpers/getLocatorBase";
+import type { LocatorSchemaWithoutPath } from "../../src/helpers/getLocatorBase";
 import type { LogEntry } from "../../src/helpers/playwrightReportLogger";
 import { type LocatorSchemaPath, POC } from "../basePage.test.poc";
 
@@ -29,12 +29,12 @@ describe("GetLocatorBase", () => {
 		expect(instance).toBeInstanceOf(GetLocatorBase);
 	});
 
-	test("addSchema() should take a LocatorSchemaPath and a ModifiedLocatorSchema as input and add a LocatorSchema to the locatorSchemas Map", () => {
+	test("addSchema() should take a LocatorSchemaPath and a LocatorSchemaWithoutPath as input and add a LocatorSchema to the locatorSchemas Map", () => {
 		const instance = new GetLocatorBase(pageObjectClass, mockLog);
 
 		const path = "topMenu" as LocatorSchemaPath;
 
-		const schema: ModifiedLocatorSchema = {
+		const schema: LocatorSchemaWithoutPath = {
 			locator: ".class",
 			locatorMethod: GetByMethod.locator,
 		};
@@ -101,13 +101,13 @@ describe("GetLocatorBase", () => {
 		const instance = new GetLocatorBase(pageObjectClass, mockLog);
 
 		const path0 = "minimalLocator" as LocatorSchemaPath;
-		const schema0: ModifiedLocatorSchema = {
+		const schema0: LocatorSchemaWithoutPath = {
 			locator: ".class",
 			locatorMethod: GetByMethod.locator,
 		};
 
 		const path1 = "minimalLocator.maximumLocator" as LocatorSchemaPath;
-		const schema1: ModifiedLocatorSchema = {
+		const schema1: LocatorSchemaWithoutPath = {
 			role: "button",
 			roleOptions: { name: "button", exact: true },
 			text: "text",
@@ -257,7 +257,7 @@ describe("GetLocatorBase", () => {
 		const instance = new GetLocatorBase(pageObjectClass, mockLog);
 
 		const path = "locator" as LocatorSchemaPath;
-		const schema: ModifiedLocatorSchema = {
+		const schema: LocatorSchemaWithoutPath = {
 			locator: ".class",
 			locatorMethod: GetByMethod.locator,
 		};
@@ -277,7 +277,7 @@ describe("GetLocatorBase", () => {
 		const instance = new GetLocatorBase(pageObjectClass, mockLog);
 
 		const path = "the.path" as LocatorSchemaPath;
-		const schema: ModifiedLocatorSchema = {
+		const schema: LocatorSchemaWithoutPath = {
 			locator: ".subClass",
 			locatorMethod: GetByMethod.locator,
 		};
@@ -303,7 +303,7 @@ describe("GetLocatorBase", () => {
 		const instance = new GetLocatorBase(pageObjectClass, mockLog);
 
 		const path = "the.path" as LocatorSchemaPath;
-		const schema: ModifiedLocatorSchema = {
+		const schema: LocatorSchemaWithoutPath = {
 			locator: ".subClass",
 			locatorMethod: GetByMethod.locator,
 		};
@@ -330,13 +330,13 @@ describe("GetLocatorBase", () => {
 		const instance = new GetLocatorBase(pageObjectClass, mockLog);
 
 		const path0 = "the" as LocatorSchemaPath;
-		const schema0: ModifiedLocatorSchema = {
+		const schema0: LocatorSchemaWithoutPath = {
 			locator: ".mainClass",
 			locatorMethod: GetByMethod.locator,
 		};
 
 		const path1 = "the.path" as LocatorSchemaPath;
-		const schema1: ModifiedLocatorSchema = {
+		const schema1: LocatorSchemaWithoutPath = {
 			locator: ".subClass",
 			locatorMethod: GetByMethod.locator,
 		};
@@ -388,7 +388,7 @@ describe("GetLocatorBase", () => {
 		const instance = new GetLocatorBase(pageObjectClass, mockLog);
 
 		const path = "minimum" as LocatorSchemaPath;
-		const schema: ModifiedLocatorSchema = {
+		const schema: LocatorSchemaWithoutPath = {
 			locatorMethod: GetByMethod.locator,
 		};
 
@@ -401,7 +401,7 @@ describe("GetLocatorBase", () => {
 		expect(locatorSchema_A).containSubset({ ...schema, locatorSchemaPath: path });
 		expect(locatorSchema_A.schemasMap.get(path)).toEqual(locatorSchema_A);
 
-		const newSchema: ModifiedLocatorSchema = {
+		const newSchema: LocatorSchemaWithoutPath = {
 			role: "button",
 			roleOptions: { name: "button", exact: true },
 			text: "text",
@@ -442,13 +442,13 @@ describe("GetLocatorBase", () => {
 		const instance = new GetLocatorBase(pageObjectClass, mockLog);
 
 		const path0 = "the" as LocatorSchemaPath;
-		const schema0: ModifiedLocatorSchema = {
+		const schema0: LocatorSchemaWithoutPath = {
 			locator: ".mainClass",
 			locatorMethod: GetByMethod.locator,
 		};
 
 		const path1 = "the.path" as LocatorSchemaPath;
-		const schema1: ModifiedLocatorSchema = {
+		const schema1: LocatorSchemaWithoutPath = {
 			locator: ".subClass",
 			locatorMethod: GetByMethod.locator,
 		};
@@ -479,13 +479,13 @@ describe("GetLocatorBase", () => {
 		const instance = new GetLocatorBase(pageObjectClass, mockLog);
 
 		const path0 = "the" as LocatorSchemaPath;
-		const schema0: ModifiedLocatorSchema = {
+		const schema0: LocatorSchemaWithoutPath = {
 			locator: ".mainClass",
 			locatorMethod: GetByMethod.locator,
 		};
 
 		const path1 = "the.path" as LocatorSchemaPath;
-		const schema1: ModifiedLocatorSchema = {
+		const schema1: LocatorSchemaWithoutPath = {
 			locator: ".subClass",
 			locatorMethod: GetByMethod.locator,
 		};
@@ -514,43 +514,43 @@ describe("GetLocatorBase", () => {
 		const instance = new GetLocatorBase(pageObjectClass, mockLog);
 
 		const path0 = "zero" as LocatorSchemaPath;
-		const schema0: ModifiedLocatorSchema = {
+		const schema0: LocatorSchemaWithoutPath = {
 			locator: ".zero",
 			locatorMethod: GetByMethod.locator,
 		};
 
 		const path1 = "zero.one" as LocatorSchemaPath;
-		const schema1: ModifiedLocatorSchema = {
+		const schema1: LocatorSchemaWithoutPath = {
 			locator: ".one",
 			locatorMethod: GetByMethod.locator,
 		};
 
 		const path2 = "zero.one.two" as LocatorSchemaPath;
-		const schema2: ModifiedLocatorSchema = {
+		const schema2: LocatorSchemaWithoutPath = {
 			locator: ".two",
 			locatorMethod: GetByMethod.locator,
 		};
 
 		const path3 = "zero.one.two.three" as LocatorSchemaPath;
-		const schema3: ModifiedLocatorSchema = {
+		const schema3: LocatorSchemaWithoutPath = {
 			locator: ".three",
 			locatorMethod: GetByMethod.locator,
 		};
 
 		const path4 = "zero.one.two.three.four" as LocatorSchemaPath;
-		const schema4: ModifiedLocatorSchema = {
+		const schema4: LocatorSchemaWithoutPath = {
 			locator: ".four",
 			locatorMethod: GetByMethod.locator,
 		};
 
 		const path5 = "zero.one.two.three.four.five" as LocatorSchemaPath;
-		const schema5: ModifiedLocatorSchema = {
+		const schema5: LocatorSchemaWithoutPath = {
 			locator: ".five",
 			locatorMethod: GetByMethod.locator,
 		};
 
 		const path6 = "zero.one.two.three.four.five.six" as LocatorSchemaPath;
-		const schema6: ModifiedLocatorSchema = {
+		const schema6: LocatorSchemaWithoutPath = {
 			locator: ".six",
 			locatorMethod: GetByMethod.locator,
 		};
@@ -613,12 +613,12 @@ describe("GetLocatorBase", () => {
 		const instance = new GetLocatorBase(pageObjectClass, mockLog);
 
 		const path0 = "minimum" as LocatorSchemaPath;
-		const schema0: ModifiedLocatorSchema = {
+		const schema0: LocatorSchemaWithoutPath = {
 			locatorMethod: GetByMethod.locator,
 		};
 
 		const path1 = "minimum.minimum" as LocatorSchemaPath;
-		const schema1: ModifiedLocatorSchema = {
+		const schema1: LocatorSchemaWithoutPath = {
 			locatorMethod: GetByMethod.locator,
 		};
 
@@ -640,7 +640,7 @@ describe("GetLocatorBase", () => {
 
 		const locator = {} as Locator;
 
-		const newSchema: ModifiedLocatorSchema = {
+		const newSchema: LocatorSchemaWithoutPath = {
 			role: "button",
 			roleOptions: {
 				name: "button",
@@ -700,7 +700,7 @@ describe("GetLocatorBase", () => {
 		const instance = new GetLocatorBase(pageObjectClass, mockLog);
 
 		const path = "button" as LocatorSchemaPath;
-		const schema: ModifiedLocatorSchema = {
+		const schema: LocatorSchemaWithoutPath = {
 			role: "button",
 			roleOptions: { name: "button", exact: true },
 			locatorMethod: GetByMethod.role,
@@ -734,14 +734,14 @@ describe("GetLocatorBase", () => {
 		const instance = new GetLocatorBase(pageObjectClass, mockLog);
 
 		const path0 = "region" as LocatorSchemaPath;
-		const schema0: ModifiedLocatorSchema = {
+		const schema0: LocatorSchemaWithoutPath = {
 			role: "region",
 			roleOptions: { name: "Personal Details", exact: true },
 			locatorMethod: GetByMethod.role,
 		};
 
 		const path1 = "region.button" as LocatorSchemaPath;
-		const schema1: ModifiedLocatorSchema = {
+		const schema1: LocatorSchemaWithoutPath = {
 			role: "button",
 			roleOptions: { name: "Save", exact: true },
 			locatorMethod: GetByMethod.role,
@@ -780,7 +780,7 @@ describe("GetLocatorBase", () => {
 		const instance = new GetLocatorBase(pageObjectClass, mockLog);
 
 		const path = "button" as LocatorSchemaPath;
-		const schema: ModifiedLocatorSchema = {
+		const schema: LocatorSchemaWithoutPath = {
 			role: "button",
 			roleOptions: { name: "button", exact: true },
 			locatorMethod: GetByMethod.role,
@@ -814,7 +814,7 @@ describe("GetLocatorBase", () => {
 		const instance = new GetLocatorBase(pageObjectClass, mockLog);
 
 		const path = "button" as LocatorSchemaPath;
-		const schema: ModifiedLocatorSchema = {
+		const schema: LocatorSchemaWithoutPath = {
 			role: "button",
 			roleOptions: { name: "button", exact: true },
 			locatorMethod: GetByMethod.role,
@@ -849,7 +849,7 @@ describe("GetLocatorBase", () => {
 		const instance = new GetLocatorBase(pageObjectClass, mockLog);
 
 		const path = "button" as LocatorSchemaPath;
-		const schema: ModifiedLocatorSchema = {
+		const schema: LocatorSchemaWithoutPath = {
 			role: "button",
 			roleOptions: { name: "button", exact: true },
 			locatorMethod: GetByMethod.role,

--- a/test/helpers/getLocatorBase.test.ts
+++ b/test/helpers/getLocatorBase.test.ts
@@ -1,4 +1,4 @@
-import { type Locator, type Page, type TestInfo } from "@playwright/test";
+import type { Locator, Page, TestInfo } from "@playwright/test";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { GetByMethod, GetLocatorBase, PlaywrightReportLogger } from "../../index";
 import type { ModifiedLocatorSchema } from "../../src/helpers/getLocatorBase";
@@ -121,11 +121,22 @@ describe("GetLocatorBase", () => {
 			title: "title",
 			titleOptions: { exact: true },
 			locator: ".class",
-			locatorOptions: { hasText: "text" },
+			locatorOptions: {
+				has: ".has" as unknown as Locator,
+				hasNot: ".hasNot" as unknown as Locator,
+				hasNotText: "hasNotText",
+				hasText: "hasText",
+			},
 			frameLocator: 'iframe[title="frame"]',
 			testId: "testId",
 			dataCy: "dataCy",
 			id: "id",
+			filter: {
+				has: ".has" as unknown as Locator,
+				hasNot: ".hasNot" as unknown as Locator,
+				hasNotText: "hasNotText",
+				hasText: "hasText",
+			},
 			locatorMethod: GetByMethod.locator,
 		};
 
@@ -137,7 +148,7 @@ describe("GetLocatorBase", () => {
 		expect(locatorSchema).toBeTypeOf("object");
 
 		const propertiesCount = Object.keys(locatorSchema).length;
-		expect(propertiesCount).toBe(25);
+		expect(propertiesCount).toBe(26);
 
 		expect(locatorSchema).toHaveProperty("locatorMethod");
 		expect(locatorSchema.locatorMethod).toBe(schema1.locatorMethod);
@@ -201,6 +212,10 @@ describe("GetLocatorBase", () => {
 
 		expect(locatorSchema).toHaveProperty("id");
 		expect(locatorSchema.id).toBe(schema1.id);
+
+		expect(locatorSchema).toHaveProperty("filter");
+		expect(locatorSchema.filter).toBeInstanceOf(Object);
+		expect(locatorSchema.filter).toEqual(schema1.locatorOptions);
 
 		expect(locatorSchema).toHaveProperty("update");
 		expect(locatorSchema.update).toBeInstanceOf(Function);

--- a/test/helpers/getLocatorBase.test.ts
+++ b/test/helpers/getLocatorBase.test.ts
@@ -148,7 +148,7 @@ describe("GetLocatorBase", () => {
 		expect(locatorSchema).toBeTypeOf("object");
 
 		const propertiesCount = Object.keys(locatorSchema).length;
-		expect(propertiesCount).toBe(26);
+		expect(propertiesCount).toBe(28);
 
 		expect(locatorSchema).toHaveProperty("locatorMethod");
 		expect(locatorSchema.locatorMethod).toBe(schema1.locatorMethod);
@@ -215,7 +215,10 @@ describe("GetLocatorBase", () => {
 
 		expect(locatorSchema).toHaveProperty("filter");
 		expect(locatorSchema.filter).toBeInstanceOf(Object);
-		expect(locatorSchema.filter).toEqual(schema1.locatorOptions);
+		expect(locatorSchema.filter).toEqual(schema1.filter);
+
+		expect(locatorSchema).toHaveProperty("addFilter");
+		expect(locatorSchema.addFilter).toBeInstanceOf(Function);
 
 		expect(locatorSchema).toHaveProperty("update");
 		expect(locatorSchema.update).toBeInstanceOf(Function);
@@ -245,7 +248,7 @@ describe("GetLocatorBase", () => {
 		expect(schema0inMap?.locatorMethod).toBe(schema0.locatorMethod);
 		expect(schema0inMap?.locatorSchemaPath).toBe(path0);
 		const retrievedSchema0 = instance.getLocatorSchema(path0);
-		expect(Object.keys(retrievedSchema0).length).toBe(8);
+		expect(Object.keys(retrievedSchema0).length).toBe(10);
 		expect(retrievedSchema0).containSubset(schema0inMap);
 		expect(retrievedSchema0).toBe(retrievedSchema0.schemasMap.get(path0));
 	});
@@ -284,7 +287,7 @@ describe("GetLocatorBase", () => {
 		// Check that the locatorSchema is as expected
 		const locatorSchema = instance.getLocatorSchema(path);
 		expect(locatorSchema).toBeTruthy();
-		expect(Object.keys(locatorSchema).length).toBe(8);
+		expect(Object.keys(locatorSchema).length).toBe(10);
 		expect(locatorSchema).containSubset({ ...schema, locatorSchemaPath: path }); // should reflect test data
 		expect(locatorSchema.schemasMap.get(path)).toEqual(locatorSchema); // should reference itself
 
@@ -310,7 +313,7 @@ describe("GetLocatorBase", () => {
 		// Check that the locatorSchema is as expected
 		const locatorSchema = instance.getLocatorSchema(path);
 		expect(locatorSchema).toBeTruthy();
-		expect(Object.keys(locatorSchema).length).toBe(8);
+		expect(Object.keys(locatorSchema).length).toBe(10);
 		expect(locatorSchema).containSubset({ ...schema, locatorSchemaPath: path }); // should reflect test data
 		expect(locatorSchema.schemasMap.get(path)).toEqual(locatorSchema); // should reference itself
 
@@ -344,7 +347,7 @@ describe("GetLocatorBase", () => {
 		// Check that the locatorSchema is as expected
 		const locatorSchema_A = instance.getLocatorSchema(path1);
 		expect(locatorSchema_A).toBeTruthy();
-		expect(Object.keys(locatorSchema_A).length).toBe(8);
+		expect(Object.keys(locatorSchema_A).length).toBe(10);
 		expect(locatorSchema_A).containSubset({ ...schema1, locatorSchemaPath: path1 }); // should reflect test data
 		expect(locatorSchema_A.schemasMap.get(path1)).toEqual(locatorSchema_A); // should reference itself
 
@@ -369,14 +372,14 @@ describe("GetLocatorBase", () => {
 		// Check that the original locatorSchema in getLocatorBase.locatorSchemas is still the same
 		const locatorSchema_C = instance.getLocatorSchema(path1);
 		expect(locatorSchema_C).toBeTruthy();
-		expect(Object.keys(locatorSchema_C).length).toBe(8);
+		expect(Object.keys(locatorSchema_C).length).toBe(10);
 		expect(locatorSchema_C).containSubset({ ...schema1, locatorSchemaPath: path1 }); // should reflect test data
 		expect(locatorSchema_C.schemasMap.get(path1)).toEqual(locatorSchema_C); // should reference itself
 
 		// Check that we can call .update() again and that the locatorSchema is updated correctly, again
 		locatorSchema_B.update({ locator: ".subClass" });
 		expect(locatorSchema_B).toBeTruthy();
-		expect(Object.keys(locatorSchema_B).length).toBe(8);
+		expect(Object.keys(locatorSchema_B).length).toBe(10);
 		expect(locatorSchema_B).containSubset({ ...schema1, locatorSchemaPath: path1 });
 		expect(locatorSchema_B.schemasMap.get(path1)).toEqual(locatorSchema_B);
 	});
@@ -394,7 +397,7 @@ describe("GetLocatorBase", () => {
 		// Check that the locatorSchema is as expected
 		const locatorSchema_A = instance.getLocatorSchema(path);
 		expect(locatorSchema_A).toBeTruthy();
-		expect(Object.keys(locatorSchema_A).length).toBe(7);
+		expect(Object.keys(locatorSchema_A).length).toBe(9);
 		expect(locatorSchema_A).containSubset({ ...schema, locatorSchemaPath: path });
 		expect(locatorSchema_A.schemasMap.get(path)).toEqual(locatorSchema_A);
 
@@ -417,16 +420,22 @@ describe("GetLocatorBase", () => {
 			testId: "testId",
 			dataCy: "dataCy",
 			id: "id",
+			filter: {
+				hasNotText: "hasNotText",
+				hasText: "text",
+			},
 			locatorMethod: GetByMethod.locator,
 		};
 
+		console.log("locatorSchema_A:\n", locatorSchema_A);
 		locatorSchema_A.update(newSchema);
-		expect(Object.keys(locatorSchema_A).length).toBe(25);
+		console.log("locatorSchema_A updated:\n", locatorSchema_A);
+		expect(Object.keys(locatorSchema_A).length).toBe(28);
 		expect(locatorSchema_A).containSubset({ ...schema, locatorSchemaPath: path });
 		expect(locatorSchema_A.schemasMap.get(path)).toEqual(locatorSchema_A);
 
 		const locatorSchema_B = instance.getLocatorSchema(path).update(newSchema);
-		expect(Object.keys(locatorSchema_B).length).toBe(25);
+		expect(Object.keys(locatorSchema_B).length).toBe(28);
 		expect(locatorSchema_B).containSubset({ ...schema, locatorSchemaPath: path });
 		expect(locatorSchema_B.schemasMap.get(path)).toEqual(locatorSchema_B);
 	});
@@ -452,7 +461,7 @@ describe("GetLocatorBase", () => {
 		// Check that the locatorSchema is as expected
 		const locatorSchema_A = instance.getLocatorSchema(path1);
 		expect(locatorSchema_A).toBeTruthy();
-		expect(Object.keys(locatorSchema_A).length).toBe(8);
+		expect(Object.keys(locatorSchema_A).length).toBe(10);
 		expect(locatorSchema_A).containSubset({ ...schema1, locatorSchemaPath: path1 }); // should reflect test data
 		expect(locatorSchema_A.schemasMap.get(path1)).toEqual(locatorSchema_A); // should reference itself
 
@@ -489,7 +498,7 @@ describe("GetLocatorBase", () => {
 		// Check that the locatorSchema is as expected
 		const locatorSchema = instance.getLocatorSchema(path1);
 		expect(locatorSchema).toBeTruthy();
-		expect(Object.keys(locatorSchema).length).toBe(8);
+		expect(Object.keys(locatorSchema).length).toBe(10);
 		expect(locatorSchema).containSubset({ ...schema1, locatorSchemaPath: path1 }); // should reflect test data
 		expect(locatorSchema.schemasMap.get(path1)).toEqual(locatorSchema); // should reference itself
 
@@ -559,7 +568,7 @@ describe("GetLocatorBase", () => {
 		// Check that the locatorSchema is as expected
 		const locatorSchema = instance.getLocatorSchema(path6);
 		expect(locatorSchema).toBeTruthy();
-		expect(Object.keys(locatorSchema).length).toBe(8);
+		expect(Object.keys(locatorSchema).length).toBe(10);
 		expect(locatorSchema).containSubset({ ...schema6, locatorSchemaPath: path6 }); // should reflect test data
 		expect(locatorSchema.schemasMap.get(path6)).toEqual(locatorSchema); // should reference itself
 		expect(locatorSchema.schemasMap.size).toBe(7);
@@ -621,7 +630,7 @@ describe("GetLocatorBase", () => {
 		// Check that the locatorSchema is as expected
 		const locatorSchema_A = instance.getLocatorSchema(path1);
 		expect(locatorSchema_A).toBeTruthy();
-		expect(Object.keys(locatorSchema_A).length).toBe(7);
+		expect(Object.keys(locatorSchema_A).length).toBe(9);
 		let path0LocatorSchema_A = locatorSchema_A.schemasMap.get(path0);
 		if (path0LocatorSchema_A) {
 			expect(Object.keys(path0LocatorSchema_A).length).toBe(2);
@@ -666,7 +675,7 @@ describe("GetLocatorBase", () => {
 		};
 
 		locatorSchema_A.updates({ 0: newSchema, 1: newSchema });
-		expect(Object.keys(locatorSchema_A).length).toBe(25);
+		expect(Object.keys(locatorSchema_A).length).toBe(27);
 		expect(locatorSchema_A).containSubset({ ...schema1, locatorSchemaPath: path1 });
 		expect(locatorSchema_A.schemasMap.get(path1)).toEqual(locatorSchema_A);
 		expect(locatorSchema_A.schemasMap.get(path0)).containSubset({ ...schema0, locatorSchemaPath: path0 });
@@ -678,7 +687,7 @@ describe("GetLocatorBase", () => {
 		}
 
 		const locatorSchema_B = instance.getLocatorSchema(path1).updates({ 0: newSchema, 1: newSchema });
-		expect(Object.keys(locatorSchema_B).length).toBe(25);
+		expect(Object.keys(locatorSchema_B).length).toBe(27);
 		expect(locatorSchema_B).containSubset({ ...schema1, locatorSchemaPath: path1 });
 		expect(locatorSchema_B.schemasMap.get(path1)).toEqual(locatorSchema_B);
 		const path0LocatorSchema_B = locatorSchema_B.schemasMap.get(path0);
@@ -704,7 +713,7 @@ describe("GetLocatorBase", () => {
 		// Check that the locatorSchema is as expected
 		const locatorSchema_A = instance.getLocatorSchema(path);
 		expect(locatorSchema_A).toBeTruthy();
-		expect(Object.keys(locatorSchema_A).length).toBe(9);
+		expect(Object.keys(locatorSchema_A).length).toBe(11);
 		expect(locatorSchema_A).containSubset({ ...schema, locatorSchemaPath: path });
 		expect(locatorSchema_A.schemasMap.get(path)).toEqual(locatorSchema_A);
 
@@ -746,7 +755,7 @@ describe("GetLocatorBase", () => {
 		// Check that the locatorSchema is as expected
 		const locatorSchema_A = instance.getLocatorSchema(path1);
 		expect(locatorSchema_A).toBeTruthy();
-		expect(Object.keys(locatorSchema_A).length).toBe(9);
+		expect(Object.keys(locatorSchema_A).length).toBe(11);
 		expect(locatorSchema_A).containSubset({ ...schema1, locatorSchemaPath: path1 });
 		expect(locatorSchema_A.schemasMap.get(path1)).toEqual(locatorSchema_A);
 
@@ -784,7 +793,7 @@ describe("GetLocatorBase", () => {
 		// Check that the locatorSchema is as expected
 		const locatorSchema_A = instance.getLocatorSchema(path);
 		expect(locatorSchema_A).toBeTruthy();
-		expect(Object.keys(locatorSchema_A).length).toBe(9);
+		expect(Object.keys(locatorSchema_A).length).toBe(11);
 		expect(locatorSchema_A).containSubset({ ...schema, locatorSchemaPath: path });
 		expect(locatorSchema_A.schemasMap.get(path)).toEqual(locatorSchema_A);
 
@@ -818,7 +827,7 @@ describe("GetLocatorBase", () => {
 		// Check that the locatorSchema is as expected
 		const locatorSchema = instance.getLocatorSchema(path);
 		expect(locatorSchema).toBeTruthy();
-		expect(Object.keys(locatorSchema).length).toBe(9);
+		expect(Object.keys(locatorSchema).length).toBe(11);
 		expect(locatorSchema).containSubset({ ...schema, locatorSchemaPath: path });
 		expect(locatorSchema.schemasMap.get(path)).toEqual(locatorSchema);
 
@@ -853,7 +862,7 @@ describe("GetLocatorBase", () => {
 		// Check that the locatorSchema is as expected
 		const locatorSchema = instance.getLocatorSchema(path);
 		expect(locatorSchema).toBeTruthy();
-		expect(Object.keys(locatorSchema).length).toBe(9);
+		expect(Object.keys(locatorSchema).length).toBe(11);
 		expect(locatorSchema).containSubset({ ...schema, locatorSchemaPath: path });
 		expect(locatorSchema.schemasMap.get(path)).toEqual(locatorSchema);
 

--- a/test/helpers/getLocatorBase.test.ts
+++ b/test/helpers/getLocatorBase.test.ts
@@ -427,9 +427,7 @@ describe("GetLocatorBase", () => {
 			locatorMethod: GetByMethod.locator,
 		};
 
-		console.log("locatorSchema_A:\n", locatorSchema_A);
 		locatorSchema_A.update(newSchema);
-		console.log("locatorSchema_A updated:\n", locatorSchema_A);
 		expect(Object.keys(locatorSchema_A).length).toBe(28);
 		expect(locatorSchema_A).containSubset({ ...schema, locatorSchemaPath: path });
 		expect(locatorSchema_A.schemasMap.get(path)).toEqual(locatorSchema_A);


### PR DESCRIPTION
---
"pomwright": 1.2.0 draft
---

# LocatorSchema filter property and getLocatorSchema.addFilter method

Changes:

- New `filter` property for `LocatorSchema`
- New `.addFilter(subPath, filterData)` method for `LocatorSchemaWithMethods`
- New `update(subPath, ModifiedLocatorSchema)` method for `LocatorSchemaWithMethods`
  - Old .update & .updates deprecated (to be removed in v.2.0.0)
- New `getNestedLocator(subPathIndices?: { [K in SubPaths<LocatorSchemaPathType, LocatorSubstring>]: number | null }): Promise<Locator>;` for both basePage.ts and getLocatorBase.ts
  - old getNestedLocator method deprecated (to be removed in v.2.0.0)
- Utilize LocatorSchemaPath instead of indices when specifying .nth(n) of a Locator in a chain
- type ModifiedLocatorSchema now exported through index.ts, makes it possible to fully or partially reuse LocatorSchema between addSchema calls both in initLocatorSchemas and between different initLocatorSchemas 

## New filter property for locatorSchema

The current `LocatorSchema` property `locatorOptions` is actually a `filter`, but it belongs to the `page.locator` method thus it only works for the `locator` property in a `LocatorSchema` object.

The new `filter` property on the other hand is usable for all locator type properties in `LocatorSchema` (locator, role, label, etc.), except for `frameLocator`.

If `filter` is specified on a `LocatorSchema`, it will always be applied and should always be the first filter to be applied/chained to the current locator in the chain of locators (only exception is `locatorOptions`).

Instead of:

```TS
this.locators.addSchema("main.products.radio@junior", {
  locator: "radio",
  locatorOptions: { hasText: "some text"}
  locatorMethod: GetByMethod.locator
});
```

We could use filter:

```TS
this.locators.addSchema("main.products.radio@junior", {
  locator: "input",
  filter: { hasText: "some text"}
  locatorMethod: GetByMethod.locator
});
```

Which as mentioned works for other locator types like role, label, placeholder, altText, title, testid, id, etc., not just locator...:

```TS
this.locators.addSchema("main.products.radio@junior", {
  role: "radio",
  filter: { hasText: "some text"}
  locatorMethod: GetByMethod.role
});
```

Another reason for this change is that a filter and a locator is NOT the same, say we have:

LocatorSchema_A:

```TS
this.locators.addSchema("main.subscription.form.item.section@header", {
  role: "region",
  roleOptions: { name: "Om abonnementet og tilleggstjenester" }
  locatorMethod: GetByMethod.role
});
```

LocatorSchema_B:

```TS
this.locators.addSchema("main.subscription.form.item.section@header", {
  locator: "section",
  filter: { hasText: "Om abonnementet og tilleggstjenester" }
  locatorMethod: GetByMethod.locator
});
```

The locator or nested locator created from LocatorSchema_A will resolve to a `section` in DOM which has the accessibility name "Om abonnementet og tillegstjenester".

While LocatorSchema_B will resolve to a `section` in DOM which contains the text "Om abonnementet og tillegstjenester" somewhere inside the element, possibly in a descendant element, case-insensitively. Note, an HTML `section` without an accessibility name is not an aria region.

But we can also combine them:

```TS
this.locators.addSchema("main.subscription.form.item.section@header", {
  role: "region",
  roleOptions: { name: "Om abonnementet og tillegstjenester" },
  filter: { hasText: "Mobil 2 GB" }
  locatorMethod: GetByMethod.role
});
```

## New .addFilter() method for locatorSchemaWithMethods

```ts
.addFilter(
  "locatorSchemaPath", 
  options { 
    has?: Locator | LocatorSchemaPath,
    hasNot?: Locator | LocatorSchemaPath,
    hasNotText?: string | RegExp,
    hasText?: string | RegExp 
  })
```

Similar to calling/chaining `.update()`/`.updates()` on `.getLocatorSchema(LocatorSchemaPath)` but using the playwright filter method. E.g.:

Instead of:

```TS
const allCheckboxesForFiltersRelatedToBrands = await poc
.getLocatorSchema("main.products.searchControls.filterType.label.checkbox")
  .updates( { 3: { locatorOptions: { hasText: /Produsent/i } } })
  .getNestedLocator();
```

Which currently only works if the LocatorSchema which the whole LocatorSchemaPath resovles to is using the `locator` property, specified in the LocatorSchema by `locatorMethod`, e.g.:

```TS
// before .update
this.locators.addSchema("main.products.searchControls.filterType", {
  locator: ".filterType",
  locatorMethod: GetByMethod.locator
});
```

In most cases it is not, as we only tend to use `locator` for structural DOM elements, and prefer aria based locators for user interactive and/or visible elements, thus updating `locatorOptions` would do nothing for a more likely scenario where the `locatorSchema` uses `role`, or in this case where we're unable to create a unique reliable locator with anything other than a testid:

```TS
this.locators.addSchema("main.products.searchControls.filterType", {
  testid: "filter-type",
  locatorMethod: GetByMethod.testid
});
```

So with .addFilter() we're able to do:

```TS
const allCheckboxesForBrandFilters = await poc
  .getLocatorSchema("main.products.searchControls.filterType.label.checkbox")
  .addFilter("main.products.searchControls.filterType", { hasText: /Produsent/i })
  .getNestedLocator();
```

Note, if one or more of the LocatorSchema we retrieve has the `filter` property defined, the filter in the locatorSchema will be applied first, then the filter(s) we add through the `.addFilter` method will be chained on. Similarly we can chain the `.addFilter` method just like we're able to chain `.update` and `.updates` methods, e.g.:

```TS
const allCheckboxesForBrandFilters = await poc
  .getLocatorSchema("main.products.searchControls.filterType.label.checkbox")
  .addFilter("main.products.searchControls.filterType", { hasText: /Produsent/i, hasNotText: /utgått/i })
  .addFilter("main.products.searchControls.filterType.label", { hasText: "Samsung" })
  .addFilter("main.products.searchControls.filterType.label", { has: poc.page.getByRole("checkbox") })
  .getNestedLocator();
```

## New update method

The current `.update()` method updates the last locatorSchema in the chain, aka. the locatorSchema which the complete (unique) LocatorSchemaPath resolves to. E.g.:
```TS
const allCheckboxesForFiltersRelatedToBrands = await poc
.getLocatorSchema("main.products.searchControls.filterType.label.checkbox")
	.updates( roleOptions: { name: /Samsung/i } )
	.getNestedLocator();
```

Will update the deepCopy of:
```TS
this.locators.addSchema("main.products.searchControls.filterType.label.checkbox", {
	role: "checkbox",
	locatorMethod: GetByMethod.role
});
```

To:
```TS
this.locators.addSchema("main.products.searchControls.filterType.label.checkbox", {
	role: "checkbox",
	roleOptions: { name: /Samsung/i }, // tada!
	locatorMethod: GetByMethod.role
});
```

While the `.updates()` method allows you to update any `LocatorSchema` that makes up the `LocatorSchemaPath` be specifying the word by a 0-based index... e.g.:

```TS
const allCheckboxesForFiltersRelatedToBrands = await poc
.getLocatorSchema("main.products.searchControls.filterType.label.checkbox")
	.updates( { 3: { locatorOptions: { hasText: /Produsent/i } } })
	.getNestedLocator();
```

Will update "main.products.searchControls.filterType"
- index 0 refrences "main" 
- index 1 refrences "main.products"
- index 2 refrences "main.products.searchControls"
- index 3 refrences "main.products.searchControls.filterType"
- and so on... 

and we can also update the same LocatorSchema with .updates as we do with .update by just specifying the correct index... But .updates also allows us to update multiple locatorSchema when invoking the method:

```TS
const allCheckboxesForFiltersRelatedToBrands = await poc
.getLocatorSchema("main.products.searchControls.filterType.label.checkbox")
	.updates({
		3: { locatorOptions: { hasText: /Produsent/i } },
		4: { locatorOptions: { hasText: /Samsung/i } },
		})
	.getNestedLocator();
```

Which might be a bit confusing, and at the very least isn't that readable. Another issue occurs when we rename LocatorSchemaPaths in our poc.locatorSchema.ts files. Since the `.updates()` method uses indices, we need to manually go through each instance where `.updates()` is invoked in our tests, Page Object Classes and helper classes/methods...

Thus, if possible, the `.update()` and `.updates()` methods should be replaced with a new and singular `.update()` method, which takes two inputs `LocatorSchemaPath` and a `ModifiedLocatorSchema`. Thus we utilize `LocatorSchemaPath` instead of index/indices for selecting which LocatorSchema in the nested chain to update.

The Old update/updates methods should be marked as deprecated and be removed in pomwright v.2.0.0

Just not sure if we'll be able to provide intellisense/auto-complete on the `LocatorSchemaPath` input to the `.update()` method. Ideally it should only suggest valid LocatorSchemaPath's, aka. substrings of the LocatorSchemaPath provided as input to the `.getLocatorSchema` method.
###### New update method usage examples:

Case A: Update the last locatorSchema in the chain
```ts
const editBtn = await profile.getLocatorSchema("content.region.details.button.edit")
	.update("content.region.details.button.edit", { 
		roleOptions: { name: "new accessibility name" }
		})
    .getNestedLocator();
```

Case B: Update a locatorSchema earlier in the chain
```ts
const editBtn = await profile.getLocatorSchema("content.region.details.button.edit")
	.update("content.region.details", { 
		roleOptions: { name: "new accessibility name" }
		})
    .getNestedLocator();
```

Case C: Update multiple locatorSchema in the chain
```ts
const editBtn = await profile.getLocatorSchema("content.region.details.button.edit")
	.update("content", {
		roleOptions: { name: "new accessibility name" }
		})
	.update("content.region", {
		roleOptions: { name: "new accessibility name" }
		})
	.update("content.region.details", {
		roleOptions: { name: "new accessibility name" }
		})
	.update("content.region.details.button", {
		roleOptions: { name: "new accessibility name" }
		})
	.update("content.region.details.button.edit", {
		roleOptions: { name: "new accessibility name" }
		})
    .getNestedLocator();

```


## Utilize LocatorSchemaPath instead of indices when specifying .nth(n) of a Locator in a chain:

#### Old:
```ts
const saveBtn = await profile.getNestedLocator("content.region.details.button.save", { 4: 2 } );

const editBtn = await profile.getLocatorSchema("content.region.details.button.edit")
    .getNestedLocator({ 2: index });
```
#### New:
```ts
const saveBtn = await profile.getNestedLocator("content.region.details.button.save", {
	"content.region.details.button.save": 2 
	});

const editBtn = await profile.getLocatorSchema("content.region.details.button.edit")
    .getNestedLocator({ "content.region.details": index }
    );
```

## Type ModifiedLocatorSchema exported through index.ts

With the type ModifiedLocatorSchema we can fully or partially reuse LocatorSchema between addSchema calls in a `initLocatorSchemas(locators: GetLocatorBase<LocatorSchemaPath>)` function or even between different `initLocatorSchemas` functions

```TS
import { GetByMethod, type GetLocatorBase, type ModifiedLocatorSchema } from "pomwright";
import { missingInputError } from "@common/page-components/errors.locatorSchema.ts"

export type LocatorSchemaPath =
	| "body"
	| "body.main"
	| "body.main.section"
	| "body.main.section@products"
	| "body.main.section@userInfo"
	| "body.main.section@userInfo.input@email"
	| "body.main.section@userInfo.inputError"
	| "body.main.section@deliveryInfo";

export function initLocatorSchemas(locators: GetLocatorBase<LocatorSchemaPath>) {
	locators.addSchema("body", {
		locator: "body",
		locatorMethod: GetByMethod.locator,
	});

	locators.addSchema("body.main", {
		locator: "main",
		locatorMethod: GetByMethod.locator,
	});

	const region: ModifiedLocatorSchema = { role: "region", locatorMethod: GetByMethod.role };

	locators.addSchema("body.main.section", {
		...region,
	});

	locators.addSchema("body.main.section@products", {
		...region,
		roleOptions: { name: "Products" },
	});

	locators.addSchema("body.main.section@userInfo", {
		...region,
		roleOptions: { name: "Contact Info" },
		filter: { hasText: /e-mail/i },
	});

	locators.addSchema("body.main.section@userInfo.input@email", {
		role: "textbox",
		roleOptions: { name: "Input your e-mail" },
		locatorMethod: GetByMethod.role,
	});

	locators.addSchema("body.main.section@userInfo.inputError", {
		...missingInputError,
	});

	locators.addSchema("body.main.section@deliveryInfo", {
		...region,
		roleOptions: { name: "Delivery Info" },
	});
}
```